### PR TITLE
Revert runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           sudo apt-get install python3-dotenv
           echo 'podman-compose == 1.0.6 --hash=sha256:48c92e6cdac1732422c6cfa803d8a905a61be4119dc0d41f9ed42c66826e9a78' > /tmp/requirements.txt
-          pip3 install --break-system-packages --require-hashes --requirement /tmp/requirements.txt
+          pip3 install --require-hashes --requirement /tmp/requirements.txt
           rm /tmp/requirements.txt
 
       - name: Docker Cache

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -68,7 +68,7 @@ jobs:
 
   ci:
     name: Continuous Integration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: changed-files
     if: ${{ needs.changed-files.outputs.run-ci == 'true' }}
     strategy:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           sudo apt-get install python3-dotenv
           echo 'podman-compose == 1.0.6 --hash=sha256:48c92e6cdac1732422c6cfa803d8a905a61be4119dc0d41f9ed42c66826e9a78' > /tmp/requirements.txt
-          pip3 install --require-hashes --requirement /tmp/requirements.txt
+          pip3 install --break-system-packages --require-hashes --requirement /tmp/requirements.txt
           rm /tmp/requirements.txt
 
       - name: Docker Cache

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
-          disable-sudo: ${{ matrix.container-context != 'docker-rootless' }}
+          disable-sudo: ${{ matrix.container-context == 'docker-default' }}
           egress-policy: block
           allowed-endpoints: >
             auth.docker.io:443
@@ -106,7 +106,7 @@ jobs:
         # Podman in the GitHub runner is out of date, so we either need to upgrade it ourselves or install an older version of podman-compose.
         # https://github.com/containers/podman-compose/issues/980#issuecomment-2199531338
         run: |
-          apt-get install python3-dotenv
+          sudo apt-get install python3-dotenv
           echo 'podman-compose == 1.0.6 --hash=sha256:48c92e6cdac1732422c6cfa803d8a905a61be4119dc0d41f9ed42c66826e9a78' > /tmp/requirements.txt
           pip3 install --require-hashes --requirement /tmp/requirements.txt
           rm /tmp/requirements.txt

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -80,9 +80,10 @@ jobs:
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
           disable-sudo: ${{ matrix.container-context == 'docker-default' }}
-          egress-policy: audit
+          egress-policy: block
           allowed-endpoints: >
             auth.docker.io:443
+            azure.archive.ubuntu.com:80
             dl-cdn.alpinelinux.org:443
             download.docker.com:443
             files.pythonhosted.org:443
@@ -91,7 +92,6 @@ jobs:
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
             pypi.org:443
-            quay.io:443
             registry-1.docker.io:443
 
       - name: Checkout

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -106,7 +106,7 @@ jobs:
         # Podman in the GitHub runner is out of date, so we either need to upgrade it ourselves or install an older version of podman-compose.
         # https://github.com/containers/podman-compose/issues/980#issuecomment-2199531338
         run: |
-          sudo apt-get install python3-dotenv
+          apt-get install python3-dotenv
           echo 'podman-compose == 1.0.6 --hash=sha256:48c92e6cdac1732422c6cfa803d8a905a61be4119dc0d41f9ed42c66826e9a78' > /tmp/requirements.txt
           pip3 install --require-hashes --requirement /tmp/requirements.txt
           rm /tmp/requirements.txt

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           echo 'podman-compose == 1.0.6 --hash=sha256:48c92e6cdac1732422c6cfa803d8a905a61be4119dc0d41f9ed42c66826e9a78' > /tmp/requirements.txt
           echo 'python-dotenv == 1.0.1 --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a' >> /tmp/requirements.txt
-          pip3 install --require-hashes --requirement /tmp/requirements.txt
+          pip3 install --break-system-packages --require-hashes --requirement /tmp/requirements.txt
           rm /tmp/requirements.txt
 
       - name: Docker Cache

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -107,7 +107,9 @@ jobs:
         # https://github.com/containers/podman-compose/issues/980#issuecomment-2199531338
         run: |
           sudo apt-get install python3-dotenv
-          sudo apt-get install python3-podman-compose
+          echo 'podman-compose == 1.0.6 --hash=sha256:48c92e6cdac1732422c6cfa803d8a905a61be4119dc0d41f9ed42c66826e9a78' > /tmp/requirements.txt
+          pip3 install --require-hashes --requirement /tmp/requirements.txt
+          rm /tmp/requirements.txt
 
       - name: Docker Cache
         id: docker-cache

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -115,7 +115,7 @@ jobs:
         id: docker-cache
         uses: ScribeMD/docker-cache@fb28c93772363301b8d0a6072ce850224b73f74e # 0.5.0
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles('./images/**/Dockerfile') }}
+          key: ${{ matrix.container-context }}-${{ runner.os }}-${{ hashFiles('./images/**/Dockerfile') }}
 
       - name: Run Tests
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -73,7 +73,7 @@ jobs:
     if: ${{ needs.changed-files.outputs.run-ci == 'true' }}
     strategy:
       matrix:
-        container-context: ["docker-default", "podman"]
+        container-context: ["docker-default"]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -73,7 +73,7 @@ jobs:
     if: ${{ needs.changed-files.outputs.run-ci == 'true' }}
     strategy:
       matrix:
-        container-context: ["docker-default", "docker-rootless"]
+        container-context: ["docker-default", "docker-rootless", "podman"]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -73,7 +73,7 @@ jobs:
     if: ${{ needs.changed-files.outputs.run-ci == 'true' }}
     strategy:
       matrix:
-        container-context: ["docker-default"]
+        container-context: ["docker-default", "docker-rootless"]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -107,9 +107,7 @@ jobs:
         # https://github.com/containers/podman-compose/issues/980#issuecomment-2199531338
         run: |
           sudo apt-get install python3-dotenv
-          echo 'podman-compose == 1.0.6 --hash=sha256:48c92e6cdac1732422c6cfa803d8a905a61be4119dc0d41f9ed42c66826e9a78' > /tmp/requirements.txt
-          pip3 install --require-hashes --requirement /tmp/requirements.txt
-          rm /tmp/requirements.txt
+          sudo apt-get install python3-podman-compose
 
       - name: Docker Cache
         id: docker-cache

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -80,7 +80,7 @@ jobs:
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
           disable-sudo: ${{ matrix.container-context == 'docker-default' }}
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
             auth.docker.io:443
             dl-cdn.alpinelinux.org:443

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -73,7 +73,7 @@ jobs:
     if: ${{ needs.changed-files.outputs.run-ci == 'true' }}
     strategy:
       matrix:
-        container-context: ["docker-default", "docker-rootless", "podman"]
+        container-context: ["docker-default", "podman"]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -106,9 +106,9 @@ jobs:
         # Podman in the GitHub runner is out of date, so we either need to upgrade it ourselves or install an older version of podman-compose.
         # https://github.com/containers/podman-compose/issues/980#issuecomment-2199531338
         run: |
+          sudo apt-get install python3-dotenv
           echo 'podman-compose == 1.0.6 --hash=sha256:48c92e6cdac1732422c6cfa803d8a905a61be4119dc0d41f9ed42c66826e9a78' > /tmp/requirements.txt
-          echo 'python-dotenv == 1.0.1 --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a' >> /tmp/requirements.txt
-          pip3 install --break-system-packages --require-hashes --requirement /tmp/requirements.txt
+          pip3 install --require-hashes --requirement /tmp/requirements.txt
           rm /tmp/requirements.txt
 
       - name: Docker Cache

--- a/src/image/Dockerfile.user-mirror
+++ b/src/image/Dockerfile.user-mirror
@@ -2,7 +2,7 @@
 
 COPY entrypoint /entrypoint
 ARG GOSU_VERSION=1.17
-ARG SETPRIV_VERSION=2.40.1
+ARG SETPRIV_VERSION=2.40.2
 ARG UTIL_LINUX_VERSION=2.39.3
 RUN chmod +x /entrypoint && /entrypoint --setup
 ENTRYPOINT ["/entrypoint", "--"]

--- a/src/image/Dockerfile.user-mirror
+++ b/src/image/Dockerfile.user-mirror
@@ -2,7 +2,7 @@
 
 COPY entrypoint /entrypoint
 ARG GOSU_VERSION=1.17
-ARG SETPRIV_VERSION=2.40.2
+ARG SETPRIV_VERSION=2.40.1
 ARG UTIL_LINUX_VERSION=2.39.3
 RUN chmod +x /entrypoint && /entrypoint --setup
 ENTRYPOINT ["/entrypoint", "--"]


### PR DESCRIPTION
## What are these changes?
Update runner configurations to fix failing CI.

## Why are these changes being made?
It looks like `ubuntu-latest` changed to `ubuntu-24.04` causing stuff to break. Reverting the runner back to `ubuntu-22.04` fixes this.