### PR TITLE
Add multi-container support

### DIFF
--- a/src/user-mirror
+++ b/src/user-mirror
@@ -4,7 +4,7 @@
 set -eC;
 VERSION='development';
 
-# Create a container and return the container ID.
+# Create container(s) and return the container ID(s).
 container_create() {
     if [ -n "$REPLACED_COMMAND" ]; then
         "$@";
@@ -15,6 +15,65 @@ container_create() {
         $COMPOSE_ENGINE --progress quiet create >/dev/null 2>&1;
         $COMPOSE_ENGINE --progress quiet ps -a --status created --format '{{.ID}}';
     fi
+}
+
+# Create host items and populate chown list
+# Args: container ID (retrieved from container_create)
+prepare_environment() {
+    # Create a list of all read/write mount destinations so they can be chown'd in the container at runtime.
+    if [ -z "$CHOWN_LIST" ]; then
+        CHOWN_LIST="$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if .RW}}"{{print .Destination}}" {{end}}{{end}}' "$1")";
+    else
+        CHOWN_LIST="$CHOWN_LIST $($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if .RW}}"{{print .Destination}}" {{end}}{{end}}' "$1")";
+    fi
+
+    # Loop through bind mounts that have a non-empty mode (`create_host_path: true` sets this), and mkdir those source paths on the host.
+    while read create_path; do
+        if [ -z "$create_path" ]; then
+            break;
+        fi
+
+        mkdir -p "$create_path" >/dev/null 2>&1 || true;
+    done <<EOF
+$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if and (eq .Type "bind") .Mode}}{{println .Source}}{{end}}{{end}}' "$1")
+EOF
+    # Loop though every pair of bind mounts and all mounts to create nested directories and files on the host.
+    #   (for example, a volume mount within a bind mount will need to be created on the host relative to the bind mount)
+    while read edge_source; do
+        if [ -z "$edge_source" ]; then
+            break;
+        fi
+
+        read edge_destination;
+
+        while read node_source; do
+            if [ -z "$node_source" ]; then
+                break;
+            fi
+
+            read node_destination;
+
+            # Find replace
+            resolved_node_destination="$(echo "$node_destination" | sed -e "s|^${edge_destination}/|${edge_source}/|g")";
+
+            if [ "$resolved_node_destination" = "$node_destination" ]; then
+                # Skip this pair if no resolution was made.
+                continue;
+            fi
+
+            if [ -f "$node_source" ]; then
+                mkdir -p "$(dirname "$resolved_node_destination")" >/dev/null 2>&1 || true;
+                touch "$resolved_node_destination";
+            else
+                mkdir -p "$resolved_node_destination" >/dev/null 2>&1 || true;
+            fi
+        done <<EOF
+$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{println .Source}}{{println .Destination}}{{end}}' "$1")
+EOF
+
+    done <<EOF
+$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if eq .Type "bind"}}{{println .Source}}{{println .Destination}}{{end}}{{end}}' "$1")
+EOF
 }
 
 # Download a release file.
@@ -246,56 +305,7 @@ if [ "$CONTAINER_ENGINE" = "docker" ] && ! docker info -f '{{println .SecurityOp
     # Parse mount information by creating a container and parsing it (but not starting it).
     if TEMP_CONTAINER_ID="$(container_create "$@")"; then
 
-        # Create a list of all read/write mount destinations so they can be chown'd in the container at runtime.
-        CHOWN_LIST="$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if .RW}}"{{print .Destination}}" {{end}}{{end}}' "$TEMP_CONTAINER_ID")";
-
-        # Loop through bind mounts that have a non-empty mode (`create_host_path: true` sets this), and mkdir those source paths on the host.
-        while read create_path; do
-            if [ -z "$create_path" ]; then
-                break;
-            fi
-
-            mkdir -p "$create_path" >/dev/null 2>&1 || true;
-        done <<EOF
-$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if and (eq .Type "bind") .Mode}}{{println .Source}}{{end}}{{end}}' "$TEMP_CONTAINER_ID")
-EOF
-        # Loop though every pair of bind mounts and all mounts to create nested directories and files on the host.
-        #   (for example, a volume mount within a bind mount will need to be created on the host relative to the bind mount)
-        while read edge_source; do
-            if [ -z "$edge_source" ]; then
-                break;
-            fi
-
-            read edge_destination;
-
-            while read node_source; do
-                if [ -z "$node_source" ]; then
-                    break;
-                fi
-
-                read node_destination;
-
-                # Find replace
-                resolved_node_destination="$(echo "$node_destination" | sed -e "s|^${edge_destination}/|${edge_source}/|g")";
-
-                if [ "$resolved_node_destination" = "$node_destination" ]; then
-                    # Skip this pair if no resolution was made.
-                    continue;
-                fi
-
-                if [ -f "$node_source" ]; then
-                    mkdir -p "$(dirname "$resolved_node_destination")" >/dev/null 2>&1 || true;
-                    touch "$resolved_node_destination";
-                else
-                    mkdir -p "$resolved_node_destination" >/dev/null 2>&1 || true;
-                fi
-            done <<EOF
-$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{println .Source}}{{println .Destination}}{{end}}' "$TEMP_CONTAINER_ID")
-EOF
-
-        done <<EOF
-$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if eq .Type "bind"}}{{println .Source}}{{println .Destination}}{{end}}{{end}}' "$TEMP_CONTAINER_ID")
-EOF
+        prepare_environment "$TEMP_CONTAINER_ID"
 
         # Cleanup.
         $CONTAINER_ENGINE container rm "$TEMP_CONTAINER_ID" >/dev/null 2>&1;

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -308,7 +308,6 @@ if [ "$CONTAINER_ENGINE" = "docker" ] && ! docker info -f '{{println .SecurityOp
 
         # Cleanup.
         $CONTAINER_ENGINE container rm "$temp_container_id" >/dev/null 2>&1;
-        break; # TODO: remove
     done <<EOF
 $(container_create "$@")
 EOF

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -17,6 +17,49 @@ container_create() {
     fi
 }
 
+# Download a release file.
+# Args: release filename, output filename, release tag (defaults to latest release it not provided)
+download_file() {
+    if [ $# -eq 3 ]; then
+        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/download/$3/$1";
+    elif [ $# -eq 2 ]; then
+        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/$1";
+    else
+        echo 'Expected at least two arguments.' >&2;
+        return 1;
+    fi
+}
+
+# Query GitHub for the latest release tag.
+get_latest_release_tag() {
+    response="$(curl -Ls -w '%{http_code}' 'https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/latest')";
+    case "$(echo "$response" | tail -1)" in
+        2*)
+            echo "$response" | \
+            grep -E '^\s*"tag_name":' | \
+            sed -E 's/.*"tag_name": "([^"]+)".*/\1/g'
+        ;;
+        *) false;;
+    esac
+}
+
+# Get the version ID of a release.
+# Args: release tag (defaults to latest release it not provided)
+get_release_version() {
+    if [ $# -eq 0 ]; then
+        response="$(curl -Ls -w '\n%{http_code}' 'https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/version')";
+    else
+        response="$(curl -Ls -w '\n%{http_code}' "https://github.com/AJGranowski/docker-user-mirror/releases/download/$1/version")";
+    fi
+
+    case "$(echo "$response" | tail -1)" in
+        2*)
+            echo "$response" | head -1
+            ;;
+        *) false;;
+    esac
+}
+
 # Create host items and populate chown list
 # Args: container ID (retrieved from container_create)
 prepare_environment() {
@@ -74,49 +117,6 @@ EOF
     done <<EOF
 $($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if eq .Type "bind"}}{{println .Source}}{{println .Destination}}{{end}}{{end}}' "$1")
 EOF
-}
-
-# Download a release file.
-# Args: release filename, output filename, release tag (defaults to latest release it not provided)
-download_file() {
-    if [ $# -eq 3 ]; then
-        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/download/$3/$1";
-    elif [ $# -eq 2 ]; then
-        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/$1";
-    else
-        echo 'Expected at least two arguments.' >&2;
-        return 1;
-    fi
-}
-
-# Query GitHub for the latest release tag.
-get_latest_release_tag() {
-    response="$(curl -Ls -w '%{http_code}' 'https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/latest')";
-    case "$(echo "$response" | tail -1)" in
-        2*)
-            echo "$response" | \
-            grep -E '^\s*"tag_name":' | \
-            sed -E 's/.*"tag_name": "([^"]+)".*/\1/g'
-        ;;
-        *) false;;
-    esac
-}
-
-# Get the version ID of a release.
-# Args: release tag (defaults to latest release it not provided)
-get_release_version() {
-    if [ $# -eq 0 ]; then
-        response="$(curl -Ls -w '\n%{http_code}' 'https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/version')";
-    else
-        response="$(curl -Ls -w '\n%{http_code}' "https://github.com/AJGranowski/docker-user-mirror/releases/download/$1/version")";
-    fi
-
-    case "$(echo "$response" | tail -1)" in
-        2*)
-            echo "$response" | head -1
-            ;;
-        *) false;;
-    esac
 }
 
 # Query GitHub to check if a release tag exists.
@@ -302,14 +302,16 @@ if [ "$CONTAINER_ENGINE" = "docker" ] && ! docker info -f '{{println .SecurityOp
     HOST_MAPPED_USER="$(id -un)";
     HOST_MAPPED_UID="$(id -u)";
 
-    # Parse mount information by creating a container and parsing it (but not starting it).
-    if TEMP_CONTAINER_ID="$(container_create "$@")"; then
-
-        prepare_environment "$TEMP_CONTAINER_ID"
+    # Loop through the containers created by this command.
+    while read temp_container_id; do
+        prepare_environment "$temp_container_id"
 
         # Cleanup.
-        $CONTAINER_ENGINE container rm "$TEMP_CONTAINER_ID" >/dev/null 2>&1;
-    fi
+        $CONTAINER_ENGINE container rm "$temp_container_id" >/dev/null 2>&1;
+        break; # TODO: remove
+    done <<EOF
+$(container_create "$@")
+EOF
 else
     HOST_MAPPED_GROUP='root';
     HOST_MAPPED_GID=0;

--- a/test/multi-container-test
+++ b/test/multi-container-test
@@ -29,7 +29,7 @@ rm compose1.yml;
 rm compose2.yml;
 
 $COMPOSE_ENGINE build;
-./user-mirror $COMPOSE_ENGINE up --wait a b;
+./user-mirror $COMPOSE_ENGINE up --no-attach a b;
 $COMPOSE_ENGINE down;
 
 # Test directory exists

--- a/test/multi-container-test
+++ b/test/multi-container-test
@@ -29,7 +29,7 @@ rm compose1.yml;
 rm compose2.yml;
 
 $COMPOSE_ENGINE build;
-./user-mirror $COMPOSE_ENGINE up --no-attach a b;
+./user-mirror $COMPOSE_ENGINE up --detach a b;
 $COMPOSE_ENGINE down;
 
 # Test directory exists

--- a/test/multi-container-test
+++ b/test/multi-container-test
@@ -29,7 +29,7 @@ rm compose1.yml;
 rm compose2.yml;
 
 $COMPOSE_ENGINE build;
-./user-mirror $COMPOSE_ENGINE up a b;
+./user-mirror $COMPOSE_ENGINE up --detach a b;
 $COMPOSE_ENGINE down;
 
 # Test directory exists

--- a/test/multi-container-test
+++ b/test/multi-container-test
@@ -2,6 +2,11 @@
 THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)";
 . "$THIS_SCRIPT_DIR/../scripts/test-utilities";
 
+# Skip on Podman
+if [ "$CONTAINER_ENGINE" = 'podman' ]; then
+    exit 0;
+fi
+
 mv compose.yml compose1.yml;
 cat <<EOF > compose2.yml
 services:
@@ -19,29 +24,9 @@ services:
       - ./:/docker-user-mirror/b
 EOF
 
-#Options:
-#      --dry-run                 Execute command in dry run mode
-#      --environment             Print environment used for interpolation.
-#      --format string           Format the output. Values: [yaml | json] (default "yaml")
-#      --hash string             Print the service config hash, one per line.
-#      --images                  Print the image names, one per line.
-#      --no-consistency          Don't check model consistency - warning: may produce invalid Compose output
-#      --no-interpolate          Don't interpolate environment variables
-#      --no-normalize            Don't normalize compose model
-#      --no-path-resolution      Don't resolve file paths
-#  -o, --output string           Save to file (default to stdout)
-#      --profiles                Print the profile names, one per line.
-#  -q, --quiet                   Only validate the configuration, don't print anything
-#      --resolve-image-digests   Pin image tags to digests
-#      --services                Print the service names, one per line.
-#      --variables               Print model variables and default values.
-#      --volumes                 Print the volume names, one per line.
-
-$COMPOSE_ENGINE -f compose1.yml -f compose2.yml config --no-interpolate -o compose.yml;
+$COMPOSE_ENGINE -f compose1.yml -f compose2.yml config --no-normalize -o compose.yml;
 rm compose1.yml;
 rm compose2.yml;
-
-cat compose.yml
 
 $COMPOSE_ENGINE build;
 ./user-mirror $COMPOSE_ENGINE up a b;

--- a/test/multi-container-test
+++ b/test/multi-container-test
@@ -30,6 +30,7 @@ rm compose2.yml;
 
 $COMPOSE_ENGINE build;
 ./user-mirror $COMPOSE_ENGINE up a b;
+$COMPOSE_ENGINE down;
 
 # Test directory exists
 if ! [ -d a ]; then
@@ -67,5 +68,3 @@ if ! [ $directory_owner_gid -eq $user_gid ]; then
     printf 'Ownership GID for "b" does not match (expected %s, got %s)\n' $user_gid $directory_owner_gid >&2;
     exit 1;
 fi
-
-$COMPOSE_ENGINE down;

--- a/test/multi-container-test
+++ b/test/multi-container-test
@@ -37,7 +37,7 @@ EOF
 #      --variables               Print model variables and default values.
 #      --volumes                 Print the volume names, one per line.
 
-$COMPOSE_ENGINE -f compose1.yml -f compose2.yml config --no-normalize --no-interpolate -o compose.yml;
+$COMPOSE_ENGINE -f compose1.yml -f compose2.yml config --no-normalize -o compose.yml;
 rm compose1.yml;
 rm compose2.yml;
 

--- a/test/multi-container-test
+++ b/test/multi-container-test
@@ -37,7 +37,7 @@ EOF
 #      --variables               Print model variables and default values.
 #      --volumes                 Print the volume names, one per line.
 
-$COMPOSE_ENGINE -f compose1.yml -f compose2.yml config --no-normalize -o compose.yml;
+$COMPOSE_ENGINE -f compose1.yml -f compose2.yml config --no-interpolate -o compose.yml;
 rm compose1.yml;
 rm compose2.yml;
 

--- a/test/multi-container-test
+++ b/test/multi-container-test
@@ -29,7 +29,7 @@ rm compose1.yml;
 rm compose2.yml;
 
 $COMPOSE_ENGINE build;
-./user-mirror $COMPOSE_ENGINE up --detach a b;
+./user-mirror $COMPOSE_ENGINE up --wait a b;
 $COMPOSE_ENGINE down;
 
 # Test directory exists

--- a/test/multi-container-test
+++ b/test/multi-container-test
@@ -1,0 +1,75 @@
+#!/bin/sh
+THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)";
+. "$THIS_SCRIPT_DIR/../scripts/test-utilities";
+
+mv compose.yml compose1.yml;
+cat <<EOF > compose2.yml
+x-docker-user-mirror-environment: &x-docker-user-mirror-environment
+services:
+  a:
+    extends:
+      file: compose1.yml
+      service: sh
+    volumes:
+      - type: volume
+        source: volume
+        target: /docker-user-mirror/a
+  b:
+    extends:
+      file: compose1.yml
+      service: sh
+    volumes:
+      - type: volume
+        source: volume
+        target: /docker-user-mirror/b
+volumes:
+  volume:
+EOF
+
+$COMPOSE_ENGINE -f compose1.yml -f compose2.yml config > compose.yml;
+rm compose1.yml;
+rm compose2.yml;
+
+cat compose.yml
+
+$COMPOSE_ENGINE build;
+./user-mirror $COMPOSE_ENGINE up a b;
+
+# Test directory exists
+if ! [ -d a ]; then
+    printf 'directory "%s" not found\n' 'a' >&2;
+    exit 1;
+fi
+
+# Test directory exists
+if ! [ -d b ]; then
+    printf 'directory "%s" not found\n' 'b' >&2;
+    exit 1;
+fi
+
+# Test file ownership matches the current user
+user_uid=$(id -u);
+user_gid=$(id -g);
+directory_owner_uid=$(stat -c "%u" a);
+directory_owner_gid=$(stat -c "%g" a);
+if ! [ $directory_owner_uid -eq $user_uid ]; then
+    printf 'Ownership UID for "a" does not match (expected %s, got %s)\n' $user_uid $directory_owner_uid >&2;
+    exit 1;
+fi
+if ! [ $directory_owner_gid -eq $user_gid ]; then
+    printf 'Ownership GID for "a" does not match (expected %s, got %s)\n' $user_gid $directory_owner_gid >&2;
+    exit 1;
+fi
+
+directory_owner_uid=$(stat -c "%u" b);
+directory_owner_gid=$(stat -c "%g" b);
+if ! [ $directory_owner_uid -eq $user_uid ]; then
+    printf 'Ownership UID for "b" does not match (expected %s, got %s)\n' $user_uid $directory_owner_uid >&2;
+    exit 1;
+fi
+if ! [ $directory_owner_gid -eq $user_gid ]; then
+    printf 'Ownership GID for "b" does not match (expected %s, got %s)\n' $user_gid $directory_owner_gid >&2;
+    exit 1;
+fi
+
+$COMPOSE_ENGINE down;

--- a/test/multi-container-test
+++ b/test/multi-container-test
@@ -4,29 +4,40 @@ THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)";
 
 mv compose.yml compose1.yml;
 cat <<EOF > compose2.yml
-x-docker-user-mirror-environment: &x-docker-user-mirror-environment
 services:
   a:
     extends:
       file: compose1.yml
       service: sh
     volumes:
-      - type: volume
-        source: volume
-        target: /docker-user-mirror/a
+      - ./:/docker-user-mirror/a
   b:
     extends:
       file: compose1.yml
       service: sh
     volumes:
-      - type: volume
-        source: volume
-        target: /docker-user-mirror/b
-volumes:
-  volume:
+      - ./:/docker-user-mirror/b
 EOF
 
-$COMPOSE_ENGINE -f compose1.yml -f compose2.yml config > compose.yml;
+#Options:
+#      --dry-run                 Execute command in dry run mode
+#      --environment             Print environment used for interpolation.
+#      --format string           Format the output. Values: [yaml | json] (default "yaml")
+#      --hash string             Print the service config hash, one per line.
+#      --images                  Print the image names, one per line.
+#      --no-consistency          Don't check model consistency - warning: may produce invalid Compose output
+#      --no-interpolate          Don't interpolate environment variables
+#      --no-normalize            Don't normalize compose model
+#      --no-path-resolution      Don't resolve file paths
+#  -o, --output string           Save to file (default to stdout)
+#      --profiles                Print the profile names, one per line.
+#  -q, --quiet                   Only validate the configuration, don't print anything
+#      --resolve-image-digests   Pin image tags to digests
+#      --services                Print the service names, one per line.
+#      --variables               Print model variables and default values.
+#      --volumes                 Print the volume names, one per line.
+
+$COMPOSE_ENGINE -f compose1.yml -f compose2.yml config --no-normalize --no-interpolate -o compose.yml;
 rm compose1.yml;
 rm compose2.yml;
 


### PR DESCRIPTION
## What are these changes?
Adds support for `docker compose up` with more than one service.

Previous behavior was to just use the first returned container to prepare the environment. This change now loops though all returned containers in sequence to prepare the environment.

## Why are these changes being made?
This script should be able to handle `docker compose up {service1} {service2}...`