### PR TITLE
Allow the scripts to be renamed without breaking updates

### DIFF
--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -107,8 +107,8 @@ update() {
         esac
     fi
 
-    echo "Installing update...";
-    download_file "$(basename "$0")" "${0}.tmp";
+    echo 'Installing update...';
+    download_file 'entrypoint' "${0}.tmp";
     mv "${0}.tmp" "$0" && echo "${latest_version} installed!"; exit 0;
 }
 

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -161,8 +161,8 @@ update() {
         esac
     fi
 
-    echo "Installing update...";
-    download_file "$(basename "$0")" "${0}.tmp";
+    echo 'Installing update...';
+    download_file 'user-mirror' "${0}.tmp";
     mv "${0}.tmp" "$0" && echo "${latest_version} installed!"; exit 0;
 }
 


### PR DESCRIPTION
## What are these changes?
Use a literal string of either `user-mirror` or `entrypoint` to download an update instead of using the script's file name.

## Why are these changes being made?
Some developers prefer adding the `.sh` extension to scripts, and we shouldn't force them to use our naming convention when using this project.