### PR TITLE
Filter error messages, fix chown bug

### DIFF
--- a/src/image/Dockerfile.user-mirror
+++ b/src/image/Dockerfile.user-mirror
@@ -4,5 +4,5 @@ COPY entrypoint /entrypoint
 ARG GOSU_VERSION=1.17
 ARG SETPRIV_VERSION=2.40.1
 ARG UTIL_LINUX_VERSION=2.39.3
-RUN chmod +x /entrypoint && /entrypoint --setup
+RUN chmod +x /entrypoint && /entrypoint --setup --verbose
 ENTRYPOINT ["/entrypoint", "--"]

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -5,6 +5,7 @@ set -eC;
 
 VERSION='development';
 exec 3>/dev/null;
+exec 4>/dev/null;
 
 check_gosu() {
     command -v gosu && \

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -286,7 +286,7 @@ else
 
     # Set the ownership of a set of items to the user.
     if [ -n "$CHOWN_LIST" ]; then
-        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3 2>&4 | true;
+        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3 2>&4 || true;
     fi
 
     # Execute using $HOST_MAPPED_UID.

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -124,15 +124,15 @@ version_to_release_tag() {
 # Parse options.
 while [ $# -gt 0 ]; do
     case $1 in
-        --debug)
-            exec 3>&1;
-            ;;
         --setup)
-            exec 3>&1;
             o_setup=true;
             ;;
         --update)
             o_update=true;
+            ;;
+        --verbose)
+            exec 3>&1;
+            exec 4>&2;
             ;;
         --version)
             echo "Version: ${VERSION}";
@@ -285,7 +285,7 @@ else
 
     # Set the ownership of a set of items to the user.
     if [ -n "$CHOWN_LIST" ]; then
-        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3;
+        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3 2>&4;
     fi
 
     # Execute using $HOST_MAPPED_UID.

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -285,7 +285,7 @@ else
 
     # Set the ownership of a set of items to the user.
     if [ -n "$CHOWN_LIST" ]; then
-        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3 2>&4;
+        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3 2>&4 | true;
     fi
 
     # Execute using $HOST_MAPPED_UID.


### PR DESCRIPTION
## What are these changes?
Rename `--debug` to `--verbose`, and add another file descriptor for verbose error messages. Additionally, never fail on `chown` in `entrypoint`.

## Why are these changes being made?
Fixes small oddities I noticed while attempting to integrate with another project.