### PR TITLE
Add executable flag back to script when updating

### DIFF
--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -110,7 +110,7 @@ update() {
 
     echo 'Installing update...';
     download_file 'entrypoint' "${0}.tmp";
-    mv "${0}.tmp" "$0" && echo "${latest_version} installed!"; exit 0;
+    mv "${0}.tmp" "$0" && chmod +x "$0" && echo "${latest_version} installed!"; exit 0;
 }
 
 # Convert "$VERSION" to "release-**" format.

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -163,7 +163,7 @@ update() {
 
     echo 'Installing update...';
     download_file 'user-mirror' "${0}.tmp";
-    mv "${0}.tmp" "$0" && echo "${latest_version} installed!"; exit 0;
+    mv "${0}.tmp" "$0" && chmod +x "$0" && echo "${latest_version} installed!"; exit 0;
 }
 
 # Convert "$VERSION" to "release-**" format.


### PR DESCRIPTION
## What are these changes?
Adds executable flag to script when applying updates.

## Why are these changes being made?
After applying an update, the script loses it's executable flag, which is annoying.