### PR TITLE
Add exec to user-mirror

### DIFF
--- a/src/user-mirror
+++ b/src/user-mirror
@@ -369,4 +369,4 @@ if [ -n "$CHOWN_LIST" ]; then
     export CHOWN_LIST;
 fi
 
-"$@";
+exec "$@";


### PR DESCRIPTION
## What are these changes?
Continuation of #73 

## Why are these changes being made?
Don't need to return to the `user-mirror` script after executing the command.