### PR TITLE
Separate file ownership for each service

### DIFF
--- a/src/compose.yml
+++ b/src/compose.yml
@@ -13,7 +13,7 @@ services:
       - CAP_DAC_OVERRIDE # Needed for Podman.
 
     cap_drop: [ALL]
-    entrypoint: [/entrypoint, --, sh]
+    entrypoint: [/entrypoint, --verbose, --, sh]
     environment:
       CAPABILITIES: # setpriv --bounding-set options. Must be a subset of cap_add. See https://www.man7.org/linux/man-pages/man1/setpriv.1.html#OPTIONS
       CHOWN_LIST: # Set by Docker User Mirror

--- a/src/compose.yml
+++ b/src/compose.yml
@@ -21,6 +21,7 @@ services:
       HOST_MAPPED_GID: # Set by Docker User Mirror
       HOST_MAPPED_USER: # Set by Docker User Mirror
       HOST_MAPPED_UID: # Set by Docker User Mirror
+      SERVICE_NAME: sh
 
     network_mode: none
     volumes:

--- a/src/compose.yml
+++ b/src/compose.yml
@@ -13,7 +13,7 @@ services:
       - CAP_DAC_OVERRIDE # Needed for Podman.
 
     cap_drop: [ALL]
-    entrypoint: [/entrypoint, --verbose, --, sh]
+    entrypoint: [/entrypoint, --, sh]
     environment:
       CAPABILITIES: # setpriv --bounding-set options. Must be a subset of cap_add. See https://www.man7.org/linux/man-pages/man1/setpriv.1.html#OPTIONS
       CHOWN_LIST: # Set by Docker User Mirror
@@ -21,7 +21,7 @@ services:
       HOST_MAPPED_GID: # Set by Docker User Mirror
       HOST_MAPPED_USER: # Set by Docker User Mirror
       HOST_MAPPED_UID: # Set by Docker User Mirror
-      SERVICE_NAME: sh
+      SERVICE_NAME: sh # Used to filter CHOWN_LIST with Docker User Mirror
 
     network_mode: none
     volumes:

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -308,7 +308,6 @@ else
             continue;
         fi
 
-        echo "chown -c \"$HOST_MAPPED_UID:$HOST_MAPPED_GID\" \"$chown_path\"";
         chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" "$chown_path" >&3;
     done <<EOF
 $CHOWN_LIST

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -308,6 +308,7 @@ else
             continue;
         fi
 
+        echo "chown -c \"$HOST_MAPPED_UID:$HOST_MAPPED_GID\" \"$chown_path\"";
         chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" "$chown_path" >&3;
     done <<EOF
 $CHOWN_LIST

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -212,7 +212,7 @@ if [ "$o_setup" = true ]; then
         fi
     fi
 else
-    set -exC;
+    set -eC;
 
     if [ -z "$HOST_MAPPED_GID" ]; then
         printf 'HOST_MAPPED_GID is unset\n' >&2;

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -212,7 +212,7 @@ if [ "$o_setup" = true ]; then
         fi
     fi
 else
-    set -eC;
+    set -exC;
 
     if [ -z "$HOST_MAPPED_GID" ]; then
         printf 'HOST_MAPPED_GID is unset\n' >&2;

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -243,6 +243,7 @@ else
     echo "HOST_MAPPED_GID=$HOST_MAPPED_GID" >&3;
     echo "HOST_MAPPED_USER=$HOST_MAPPED_USER" >&3;
     echo "HOST_MAPPED_UID=$HOST_MAPPED_UID" >&3;
+    echo "SERVICE_NAME=$SERVICE_NAME" >&3;
 
     # Create/replace user if non-root.
     if [ $HOST_MAPPED_UID -ne 0 ] && [ "$HOST_MAPPED_USER" != 'root' ]; then

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -285,9 +285,32 @@ else
     fi
 
     # Set the ownership of a set of items to the user.
-    if [ -n "$CHOWN_LIST" ]; then
-        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3 2>&4 || true;
-    fi
+    while read service_name; do
+        if [ -z "$service_name" ]; then
+            continue;
+        fi
+
+        case $service_name in
+            /*)
+                chown_path="$service_name";
+                unset service_name;
+                ;;
+            *) read chown_path;;
+        esac
+
+        if [ -n "$service_name" ] && [ "$service_name" != "$SERVICE_NAME" ]; then
+            continue;
+        fi
+
+        if ! [ -e "$chown_path" ]; then
+            printf "cannot access '%s': No such file or directory\n" "$chown_path" >&4;
+            continue;
+        fi
+
+        chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" "$chown_path" >&3;
+    done <<EOF
+$CHOWN_LIST
+EOF
 
     # Execute using $HOST_MAPPED_UID.
     if check_setpriv >/dev/null 2>&1; then

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -336,7 +336,7 @@ for arg do
                     set -- "$@" "$arg";
                 fi
 
-                set -- "$@" '-e' "HOST_MAPPED_GID=$HOST_MAPPED_GID" '-e' "HOST_MAPPED_GROUP=$HOST_MAPPED_GROUP" '-e' "HOST_MAPPED_UID=$HOST_MAPPED_GROUP" '-e' "HOST_MAPPED_USER=$HOST_MAPPED_USER";
+                set -- "$@" '-e' "HOST_MAPPED_GID=$HOST_MAPPED_GID" '-e' "HOST_MAPPED_GROUP=$HOST_MAPPED_GROUP" '-e' "HOST_MAPPED_UID=$HOST_MAPPED_UID" '-e' "HOST_MAPPED_USER=$HOST_MAPPED_USER";
                 if [ -n "$CHOWN_LIST" ]; then
                     set -- "$@" '-e' "CHOWN_LIST=$CHOWN_LIST";
                 fi

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -336,9 +336,9 @@ for arg do
                     set -- "$@" "$arg";
                 fi
 
-                set -- "$@" '-e' 'HOST_MAPPED_GID' '-e' 'HOST_MAPPED_GROUP' '-e' 'HOST_MAPPED_UID' '-e' 'HOST_MAPPED_USER';
+                set -- "$@" '-e' "HOST_MAPPED_GID=$HOST_MAPPED_GID" '-e' "HOST_MAPPED_GROUP=$HOST_MAPPED_GROUP" '-e' "HOST_MAPPED_UID=$HOST_MAPPED_GROUP" '-e' "HOST_MAPPED_USER=$HOST_MAPPED_USER";
                 if [ -n "$CHOWN_LIST" ]; then
-                    set -- "$@" '-e' 'CHOWN_LIST';
+                    set -- "$@" '-e' "CHOWN_LIST=$CHOWN_LIST";
                 fi
 
                 search_for_insert=0;

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -63,12 +63,12 @@ get_release_version() {
 # Create host items and populate chown list
 # Args: container ID (retrieved from container_create)
 prepare_environment() {
+    # Grab the SERVICE_NAME environment variable if it exists.
+    service_name="$($CONTAINER_ENGINE inspect --format '{{range .Config.Env}}{{if and (gt (len .) 13) (eq (slice . 0 13) "SERVICE_NAME=")}}{{slice . 13}}{{end}}{{end}}' "$1")";
+
     # Create a list of all read/write mount destinations so they can be chown'd in the container at runtime.
-    if [ -z "$CHOWN_LIST" ]; then
-        CHOWN_LIST="$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if .RW}}"{{print .Destination}}" {{end}}{{end}}' "$1")";
-    else
-        CHOWN_LIST="$CHOWN_LIST $($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if .RW}}"{{print .Destination}}" {{end}}{{end}}' "$1")";
-    fi
+    CHOWN_LIST="$CHOWN_LIST
+$($CONTAINER_ENGINE inspect --format "{{range .Mounts}}{{if .RW}}{{println \"$service_name\"}}{{println .Destination}}{{end}}{{end}}" "$1")";
 
     # Loop through bind mounts that have a non-empty mode (`create_host_path: true` sets this), and mkdir those source paths on the host.
     while read create_path; do
@@ -336,9 +336,9 @@ for arg do
                     set -- "$@" "$arg";
                 fi
 
-                set -- "$@" '-e' "HOST_MAPPED_GID=$HOST_MAPPED_GID" '-e' "HOST_MAPPED_GROUP=$HOST_MAPPED_GROUP" '-e' "HOST_MAPPED_UID=$HOST_MAPPED_UID" '-e' "HOST_MAPPED_USER=$HOST_MAPPED_USER";
+                set -- "$@" '-e' 'HOST_MAPPED_GID' '-e' 'HOST_MAPPED_GROUP' '-e' 'HOST_MAPPED_UID' '-e' 'HOST_MAPPED_USER';
                 if [ -n "$CHOWN_LIST" ]; then
-                    set -- "$@" '-e' "CHOWN_LIST=$CHOWN_LIST";
+                    set -- "$@" '-e' 'CHOWN_LIST';
                 fi
 
                 search_for_insert=0;


### PR DESCRIPTION
## What are these changes?
* Switch the delimiter of `CHOWN_LIST` from quoted strings to newline.
* Change structure of `CHOWN_LIST` to accept key/value pairs.
* Filter `CHOWN_LIST` in the container based on the new `SERVICE_NAME` environment variable.

## Why are these changes being made?
This change resolves:
* #72