### PR TITLE
Fix `--file` option handling

### DIFF
--- a/src/user-mirror
+++ b/src/user-mirror
@@ -253,6 +253,7 @@ fi
 #   command string to create (but not start) a container for parsing. This is a workaround for POSIX shell only having
 #   one array object (the argument list).
 COMPOSE_FILES="";
+add_compose_file=false;
 first_iteration=true;
 search_for_replace=4;
 for arg do
@@ -286,11 +287,14 @@ for arg do
                 ;;
         esac
     else
-        case $arg in
-            -f|--file)
-                COMPOSE_FILES="$1";
-                ;;
-        esac
+        if [ "$add_compose_file" =  true ]; then
+            unset add_compose_file;
+            COMPOSE_FILES="$arg";
+        else
+            case $arg in
+                -f|--file) add_compose_file=true;;
+            esac
+        fi
         set -- "$@" "$arg";
     fi
 done


### PR DESCRIPTION
## What are these changes?
Remove positional variables from the container create rewrite loop.

## Why are these changes being made?
`$1` doesn't work to get the next argument while rebuilding the argument array. We need to proceed to the next loop to get that argument.