### PR TITLE
Combine host variables into `HOST_USER`

### DIFF
--- a/src/compose.yml
+++ b/src/compose.yml
@@ -17,10 +17,7 @@ services:
     environment:
       CAPABILITIES: # setpriv --bounding-set options. Must be a subset of cap_add. See https://www.man7.org/linux/man-pages/man1/setpriv.1.html#OPTIONS
       CHOWN_LIST: # Set by Docker User Mirror
-      HOST_MAPPED_GROUP: # Set by Docker User Mirror
-      HOST_MAPPED_GID: # Set by Docker User Mirror
-      HOST_MAPPED_USER: # Set by Docker User Mirror
-      HOST_MAPPED_UID: # Set by Docker User Mirror
+      HOST_USER: # Set by Docker User Mirror
       SERVICE_NAME: sh # Used to filter CHOWN_LIST with Docker User Mirror
 
     network_mode: none

--- a/src/compose.yml
+++ b/src/compose.yml
@@ -18,7 +18,7 @@ services:
       USER_MIRROR_CAPABILITIES: # setpriv --bounding-set options. Must be a subset of cap_add. See https://www.man7.org/linux/man-pages/man1/setpriv.1.html#OPTIONS
       USER_MIRROR_CHOWN_LIST: # Set by Docker User Mirror
       USER_MIRROR_HOST_USER: # Set by Docker User Mirror
-      USER_MIRROR_SERVICE_NAME: sh # USER_MIRROR_CHOWN_LIST filter used by Docker User Mirror
+      USER_MIRROR_SERVICE_NAME: service-name # USER_MIRROR_CHOWN_LIST filter used by Docker User Mirror
 
     network_mode: none
     volumes:

--- a/src/compose.yml
+++ b/src/compose.yml
@@ -15,10 +15,10 @@ services:
     cap_drop: [ALL]
     entrypoint: [/entrypoint, --, sh]
     environment:
-      CAPABILITIES: # setpriv --bounding-set options. Must be a subset of cap_add. See https://www.man7.org/linux/man-pages/man1/setpriv.1.html#OPTIONS
-      CHOWN_LIST: # Set by Docker User Mirror
-      HOST_USER: # Set by Docker User Mirror
-      SERVICE_NAME: sh # Used to filter CHOWN_LIST with Docker User Mirror
+      USER_MIRROR_CAPABILITIES: # setpriv --bounding-set options. Must be a subset of cap_add. See https://www.man7.org/linux/man-pages/man1/setpriv.1.html#OPTIONS
+      USER_MIRROR_CHOWN_LIST: # Set by Docker User Mirror
+      USER_MIRROR_HOST_USER: # Set by Docker User Mirror
+      USER_MIRROR_SERVICE_NAME: sh # Used to filter CHOWN_LIST with Docker User Mirror
 
     network_mode: none
     volumes:

--- a/src/compose.yml
+++ b/src/compose.yml
@@ -18,7 +18,7 @@ services:
       USER_MIRROR_CAPABILITIES: # setpriv --bounding-set options. Must be a subset of cap_add. See https://www.man7.org/linux/man-pages/man1/setpriv.1.html#OPTIONS
       USER_MIRROR_CHOWN_LIST: # Set by Docker User Mirror
       USER_MIRROR_HOST_USER: # Set by Docker User Mirror
-      USER_MIRROR_SERVICE_NAME: sh # Used to filter CHOWN_LIST with Docker User Mirror
+      USER_MIRROR_SERVICE_NAME: sh # USER_MIRROR_CHOWN_LIST filter used by Docker User Mirror
 
     network_mode: none
     volumes:

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -229,8 +229,8 @@ if [ "$o_setup" = true ]; then
 else
     set -eC;
 
-    if [ -z "$HOST_USER" ]; then
-        printf 'HOST_USER is unset\n' >&2;
+    if [ -z "$USER_MIRROR_HOST_USER" ]; then
+        printf 'USER_MIRROR_HOST_USER is unset\n' >&2;
         guard_failure=true;
     fi
 
@@ -238,14 +238,14 @@ else
         exit 1;
     fi
 
-    echo "CAPABILITIES=${CAPABILITIES}" >&3;
-    echo "HOST_USER=${HOST_USER}" >&3;
-    echo "SERVICE_NAME=${SERVICE_NAME}" >&3;
+    echo "USER_MIRROR_CAPABILITIES=${USER_MIRROR_CAPABILITIES}" >&3;
+    echo "USER_MIRROR_HOST_USER=${USER_MIRROR_HOST_USER}" >&3;
+    echo "USER_MIRROR_SERVICE_NAME=${USER_MIRROR_SERVICE_NAME}" >&3;
 
-    host_user_name="$(extract_index "$HOST_USER" 0 ':')";
-    host_user_id="$(extract_index "$HOST_USER" 1 ':')";
-    host_user_group="$(extract_index "$HOST_USER" 2 ':')";
-    host_user_gid="$(extract_index "$HOST_USER" 3 ':')";
+    host_user_name="$(extract_index "$USER_MIRROR_HOST_USER" 0 ':')";
+    host_user_id="$(extract_index "$USER_MIRROR_HOST_USER" 1 ':')";
+    host_user_group="$(extract_index "$USER_MIRROR_HOST_USER" 2 ':')";
+    host_user_gid="$(extract_index "$USER_MIRROR_HOST_USER" 3 ':')";
 
     # Create/replace user if non-root.
     if [ "$host_user_id" -ne 0 ] && [ "$host_user_name" != 'root' ]; then
@@ -297,7 +297,7 @@ else
             *) read chown_path;;
         esac
 
-        if [ -n "$service_name" ] && [ "$service_name" != "$SERVICE_NAME" ]; then
+        if [ -n "$service_name" ] && [ "$service_name" != "$USER_MIRROR_SERVICE_NAME" ]; then
             continue;
         fi
 
@@ -308,19 +308,19 @@ else
 
         chown -c "${host_user_id}:${host_user_gid}" "$chown_path" >&3;
     done <<EOF
-$CHOWN_LIST
+$USER_MIRROR_CHOWN_LIST
 EOF
 
-    if [ -n "$CAPABILITIES" ]; then
-        capabilities="-all,$CAPABILITIES";
+    if [ -n "$USER_MIRROR_CAPABILITIES" ]; then
+        capabilities="-all,$USER_MIRROR_CAPABILITIES";
     else
         capabilities='-all';
     fi
 
-    unset CAPABILITIES;
-    unset CHOWN_LIST;
-    unset HOST_USER;
-    unset SERVICE_NAME;
+    unset USER_MIRROR_CAPABILITIES;
+    unset USER_MIRROR_CHOWN_LIST;
+    unset USER_MIRROR_HOST_USER;
+    unset USER_MIRROR_SERVICE_NAME;
 
     # Execute using $HOST_MAPPED_UID.
     if check_setpriv >/dev/null 2>&1; then

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -249,6 +249,8 @@ else
 
     # Create/replace user if non-root.
     if [ "$host_user_id" -ne 0 ] && [ "$host_user_name" != 'root' ]; then
+        export SHELL='/bin/sh';
+
         uid_username="$(awk -F: "\$3 == ${host_user_id} {print \$1}" /etc/passwd)";
         if id -u "$uid_username" >/dev/null 2>&1; then
             echo "Removing user matching UID ${host_user_id}: $(print_user $uid_username)" >&3;
@@ -267,16 +269,19 @@ else
         gid_groupname="$(awk -F: "\$3 == ${host_user_gid} {print \$1}" /etc/group)";
 
         if command -v useradd >/dev/null; then
-            useradd -c 'Mirrored Host User' -g "$host_user_gid" -m -s /bin/sh -u "$host_user_id" "$host_user_name" 2>&4;
+            useradd -c 'Mirrored Host User' -g "$host_user_gid" -m -s "$SHELL" -u "$host_user_id" "$host_user_name" 2>&4;
         else
-            adduser -c 'Mirrored Host User' -D -G "$gid_groupname" -s /bin/sh -u "$host_user_id" "$host_user_name" 2>&4;
+            adduser -c 'Mirrored Host User' -D -G "$gid_groupname" -s "$SHELL" -u "$host_user_id" "$host_user_name" 2>&4;
         fi
         echo "Created user: $(print_user "$host_user_name")" >&3;
 
-        HOME_DIR="/home/${host_user_name}";
+        export HOME="/home/${host_user_name}";
     else
-        HOME_DIR="/root";
+        export HOME='/root';
     fi
+
+    export LOGNAME="$host_user_name";
+    export USER="$host_user_name";
 
     # Set the ownership of a set of items to the user.
     while read service_name; do
@@ -306,19 +311,24 @@ else
 $CHOWN_LIST
 EOF
 
+    if [ -n "$CAPABILITIES" ]; then
+        capabilities="-all,$CAPABILITIES";
+    else
+        capabilities='-all';
+    fi
+
+    unset CAPABILITIES;
+    unset CHOWN_LIST;
+    unset HOST_USER;
+    unset SERVICE_NAME;
+
     # Execute using $HOST_MAPPED_UID.
     if check_setpriv >/dev/null 2>&1; then
-        if [ -n "$CAPABILITIES" ]; then
-            capabilities="-all,$CAPABILITIES";
-        else
-            capabilities='-all';
-        fi
-
-        echo "HOME=${HOME_DIR} LOGNAME=${host_user_name} SHELL=/bin/sh USER=${host_user_name} exec setpriv --bounding-set \"$capabilities\" --init-groups --no-new-privs --reuid=${host_user_id} --regid=${host_user_gid} ..." >&3;
-        HOME="$HOME_DIR" LOGNAME="$host_user_name" SHELL='/bin/sh' USER="$host_user_name" exec setpriv --bounding-set "$capabilities" --init-groups --no-new-privs --reuid=${host_user_id} --regid=${host_user_gid} "$@";
+        echo "exec setpriv --bounding-set \"$capabilities\" --init-groups --no-new-privs --reuid=${host_user_id} --regid=${host_user_gid} ..." >&3;
+        exec setpriv --bounding-set "$capabilities" --init-groups --no-new-privs --reuid=${host_user_id} --regid=${host_user_gid} "$@";
     elif command -v gosu >/dev/null; then
-        echo "HOME=${HOME_DIR} LOGNAME=${host_user_name} SHELL=/bin/sh USER=${host_user_name} exec gosu \"${host_user_id}:${host_user_gid}\" ..." >&3;
-        HOME="$HOME_DIR" LOGNAME="$host_user_name" SHELL='/bin/sh' USER="$host_user_name" exec gosu "${host_user_id}:${host_user_gid}" "$@";
+        echo "exec gosu \"${host_user_id}:${host_user_gid}\" ..." >&3;
+        exec gosu "${host_user_id}:${host_user_gid}" "$@";
     else
         printf 'Unable to set user\n' >&2;
         exit 1;

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -271,7 +271,7 @@ else
         if command -v useradd >/dev/null; then
             useradd -c 'Mirrored Host User' -g "$host_user_gid" -m -s "$SHELL" -u "$host_user_id" "$host_user_name" 2>&4;
         else
-            adduser -c 'Mirrored Host User' -D -G "$gid_groupname" -s "$SHELL" -u "$host_user_id" "$host_user_name" 2>&4;
+            adduser -D -g 'Mirrored Host User' -G "$gid_groupname" -s "$SHELL" -u "$host_user_id" "$host_user_name" 2>&4;
         fi
         echo "Created user: $(print_user "$host_user_name")" >&3;
 

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -19,6 +19,21 @@ check_setpriv() {
     setpriv --reuid="$(id -u nobody)" --regid="$(id -g nobody)" --clear-groups true;
 }
 
+# Split strings by a delimiter and extract an index. Uses space as a delimiter by default.
+extract_index() (
+    str="$1";
+    count="${2:-0}";
+    delimiter="${3:- }";
+    while [ $count -gt 0 ]; do
+        : $((count -= 1));
+        case "$str" in
+            *${delimiter}*) str="${str#*${delimiter}}";;
+            *) str='';;
+        esac
+    done
+    echo "${str%%${delimiter}*}";
+)
+
 # Download a release file.
 # Args: release filename, output filename, release tag (defaults to latest release it not provided)
 download_file() {
@@ -214,23 +229,8 @@ if [ "$o_setup" = true ]; then
 else
     set -eC;
 
-    if [ -z "$HOST_MAPPED_GID" ]; then
-        printf 'HOST_MAPPED_GID is unset\n' >&2;
-        guard_failure=true;
-    fi
-
-    if [ -z "$HOST_MAPPED_GROUP" ]; then
-        printf 'HOST_MAPPED_GROUP is unset\n' >&2;
-        guard_failure=true;
-    fi
-
-    if [ -z "$HOST_MAPPED_UID" ]; then
-        printf 'HOST_MAPPED_UID is unset\n' >&2;
-        guard_failure=true;
-    fi
-
-    if [ -z "$HOST_MAPPED_USER" ]; then
-        printf 'HOST_MAPPED_USER is unset\n' >&2;
+    if [ -z "$HOST_USER" ]; then
+        printf 'HOST_USER is unset\n' >&2;
         guard_failure=true;
     fi
 
@@ -238,27 +238,20 @@ else
         exit 1;
     fi
 
-    echo "CAPABILITIES=$CAPABILITIES" >&3;
-    echo "HOST_MAPPED_GROUP=$HOST_MAPPED_GROUP" >&3;
-    echo "HOST_MAPPED_GID=$HOST_MAPPED_GID" >&3;
-    echo "HOST_MAPPED_USER=$HOST_MAPPED_USER" >&3;
-    echo "HOST_MAPPED_UID=$HOST_MAPPED_UID" >&3;
-    echo "SERVICE_NAME=$SERVICE_NAME" >&3;
+    echo "CAPABILITIES=${CAPABILITIES}" >&3;
+    echo "HOST_USER=${HOST_USER}" >&3;
+    echo "SERVICE_NAME=${SERVICE_NAME}" >&3;
+
+    host_user_name="$(extract_index "$HOST_USER" 0 ':')";
+    host_user_id="$(extract_index "$HOST_USER" 1 ':')";
+    host_user_group="$(extract_index "$HOST_USER" 2 ':')";
+    host_user_gid="$(extract_index "$HOST_USER" 3 ':')";
 
     # Create/replace user if non-root.
-    if [ $HOST_MAPPED_UID -ne 0 ] && [ "$HOST_MAPPED_USER" != 'root' ]; then
-        if id -u "$HOST_MAPPED_USER" >/dev/null 2>&1; then
-            echo "Removing user matching $HOST_MAPPED_USER: $(print_user $HOST_MAPPED_USER)" >&3;
-            if command -v userdel >/dev/null; then
-                userdel "$HOST_MAPPED_USER";
-            else
-                deluser "$HOST_MAPPED_USER" 2>/dev/null;
-            fi
-        fi
-
-        uid_username="$(awk -F: "\$3 == $HOST_MAPPED_UID {print \$1}" /etc/passwd)";
+    if [ "$host_user_id" -ne 0 ] && [ "$host_user_name" != 'root' ]; then
+        uid_username="$(awk -F: "\$3 == ${host_user_id} {print \$1}" /etc/passwd)";
         if id -u "$uid_username" >/dev/null 2>&1; then
-            echo "Removing user matching UID $HOST_MAPPED_UID: $(print_user $uid_username)" >&3;
+            echo "Removing user matching UID ${host_user_id}: $(print_user $uid_username)" >&3;
             if command -v userdel >/dev/null; then
                 userdel "$uid_username";
             else
@@ -267,20 +260,20 @@ else
         fi
 
         if command -v groupadd >/dev/null; then
-            groupadd -g $HOST_MAPPED_GID "$HOST_MAPPED_GROUP" || true;
+            groupadd -g "$host_user_gid" "$host_user_group" || true;
         else
-            addgroup -g $HOST_MAPPED_GID "$HOST_MAPPED_GROUP" || true;
+            addgroup -g "$host_user_gid" "$host_user_group" || true;
         fi
-        gid_groupname="$(awk -F: "\$3 == $HOST_MAPPED_GID {print \$1}" /etc/group)";
+        gid_groupname="$(awk -F: "\$3 == ${host_user_gid} {print \$1}" /etc/group)";
 
         if command -v useradd >/dev/null; then
-            useradd -g $HOST_MAPPED_GID -m -s /bin/sh -u $HOST_MAPPED_UID $HOST_MAPPED_USER 2>&4;
+            useradd -c 'Mirrored Host User' -g "$host_user_gid" -m -s /bin/sh -u "$host_user_id" "$host_user_name" 2>&4;
         else
-            adduser -D -G "$gid_groupname" -s /bin/sh -u $HOST_MAPPED_UID $HOST_MAPPED_USER 2>&4;
+            adduser -c 'Mirrored Host User' -D -G "$gid_groupname" -s /bin/sh -u "$host_user_id" "$host_user_name" 2>&4;
         fi
-        echo "Created user: $(print_user "$HOST_MAPPED_USER")" >&3;
+        echo "Created user: $(print_user "$host_user_name")" >&3;
 
-        HOME_DIR="/home/$HOST_MAPPED_USER";
+        HOME_DIR="/home/${host_user_name}";
     else
         HOME_DIR="/root";
     fi
@@ -303,12 +296,12 @@ else
             continue;
         fi
 
-        if ! [ -e "$chown_path" ]; then
+        if [ ! -e "$chown_path" ]; then
             printf "cannot access '%s': No such file or directory\n" "$chown_path" >&4;
             continue;
         fi
 
-        chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" "$chown_path" >&3;
+        chown -c "${host_user_id}:${host_user_gid}" "$chown_path" >&3;
     done <<EOF
 $CHOWN_LIST
 EOF
@@ -321,11 +314,11 @@ EOF
             capabilities='-all';
         fi
 
-        echo "HOME=$HOME_DIR LOGNAME=$HOST_MAPPED_USER SHELL=/bin/sh USER=$HOST_MAPPED_USER exec setpriv --bounding-set \"$capabilities\" --init-groups --no-new-privs --reuid=$HOST_MAPPED_UID --regid=$HOST_MAPPED_GID ..." >&3;
-        HOME="$HOME_DIR" LOGNAME="$HOST_MAPPED_USER" SHELL='/bin/sh' USER="$HOST_MAPPED_USER" exec setpriv --bounding-set "$capabilities" --init-groups --no-new-privs --reuid=$HOST_MAPPED_UID --regid=$HOST_MAPPED_GID "$@";
+        echo "HOME=${HOME_DIR} LOGNAME=${host_user_name} SHELL=/bin/sh USER=${host_user_name} exec setpriv --bounding-set \"$capabilities\" --init-groups --no-new-privs --reuid=${host_user_id} --regid=${host_user_gid} ..." >&3;
+        HOME="$HOME_DIR" LOGNAME="$host_user_name" SHELL='/bin/sh' USER="$host_user_name" exec setpriv --bounding-set "$capabilities" --init-groups --no-new-privs --reuid=${host_user_id} --regid=${host_user_gid} "$@";
     elif command -v gosu >/dev/null; then
-        echo "HOME=$HOME_DIR LOGNAME=$HOST_MAPPED_USER SHELL=/bin/sh USER=$HOST_MAPPED_USER exec gosu "$HOST_MAPPED_UID:$HOST_MAPPED_GID" ..." >&3;
-        HOME="$HOME_DIR" LOGNAME="$HOST_MAPPED_USER" SHELL='/bin/sh' USER="$HOST_MAPPED_USER" exec gosu "$HOST_MAPPED_UID:$HOST_MAPPED_GID" "$@";
+        echo "HOME=${HOME_DIR} LOGNAME=${host_user_name} SHELL=/bin/sh USER=${host_user_name} exec gosu \"${host_user_id}:${host_user_gid}\" ..." >&3;
+        HOME="$HOME_DIR" LOGNAME="$host_user_name" SHELL='/bin/sh' USER="$host_user_name" exec gosu "${host_user_id}:${host_user_gid}" "$@";
     else
         printf 'Unable to set user\n' >&2;
         exit 1;

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -63,11 +63,11 @@ get_release_version() {
 # Create host items and populate chown list
 # Args: container ID (retrieved from container_create)
 prepare_environment() {
-    # Grab the SERVICE_NAME environment variable if it exists.
-    service_name="$($CONTAINER_ENGINE inspect --format '{{range .Config.Env}}{{if and (gt (len .) 13) (eq (slice . 0 13) "SERVICE_NAME=")}}{{slice . 13}}{{end}}{{end}}' "$1")";
+    # Grab the USER_MIRROR_SERVICE_NAME environment variable if it exists.
+    service_name="$($CONTAINER_ENGINE inspect --format '{{range .Config.Env}}{{if and (gt (len .) 13) (eq (slice . 0 13) "USER_MIRROR_SERVICE_NAME=")}}{{slice . 13}}{{end}}{{end}}' "$1")";
 
     # Create a list of all read/write mount destinations so they can be chown'd in the container at runtime.
-    CHOWN_LIST="$CHOWN_LIST
+    USER_MIRROR_CHOWN_LIST="$USER_MIRROR_CHOWN_LIST
 $($CONTAINER_ENGINE inspect --format "{{range .Mounts}}{{if .RW}}{{println \"$service_name\"}}{{println .Destination}}{{end}}{{end}}" "$1")";
 
     # Loop through bind mounts that have a non-empty mode (`create_host_path: true` sets this), and mkdir those source paths on the host.
@@ -298,7 +298,7 @@ done
 
 # If Docker and not rootless, then we have some work to do.
 if [ "$CONTAINER_ENGINE" = "docker" ] && ! docker info -f '{{println .SecurityOptions}}' | grep 'rootless' 1>/dev/null; then
-    HOST_USER="$(id -un):$(id -u):$(id -gn):$(id -g)";
+    USER_MIRROR_HOST_USER="$(id -un):$(id -u):$(id -gn):$(id -g)";
 
     # Loop through the containers created by this command.
     while read temp_container_id; do
@@ -310,7 +310,7 @@ if [ "$CONTAINER_ENGINE" = "docker" ] && ! docker info -f '{{println .SecurityOp
 $(container_create "$@")
 EOF
 else
-    HOST_USER='root:0:root:0';
+    USER_MIRROR_HOST_USER='root:0:root:0';
 fi
 
 # Restore the args list we may have mangled before, and insert runtime arguments.
@@ -331,9 +331,9 @@ for arg do
                     set -- "$@" "$arg";
                 fi
 
-                set -- "$@" '-e' "HOST_USER=${HOST_USER}";
-                if [ -n "$CHOWN_LIST" ]; then
-                    set -- "$@" '-e' "CHOWN_LIST=${CHOWN_LIST}";
+                set -- "$@" '-e' "USER_MIRROR_HOST_USER=${USER_MIRROR_HOST_USER}";
+                if [ -n "$USER_MIRROR_CHOWN_LIST" ]; then
+                    set -- "$@" '-e' "USER_MIRROR_CHOWN_LIST=${USER_MIRROR_CHOWN_LIST}";
                 fi
 
                 search_for_insert=0;
@@ -353,9 +353,9 @@ for arg do
     fi
 done
 
-export HOST_USER;
-if [ -n "$CHOWN_LIST" ]; then
-    export CHOWN_LIST;
+export USER_MIRROR_HOST_USER;
+if [ -n "$USER_MIRROR_CHOWN_LIST" ]; then
+    export USER_MIRROR_CHOWN_LIST;
 fi
 
 exec "$@";

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -280,11 +280,8 @@ for arg do
 
         # Decrement for non-option arguments.
         case $arg in
-            -*)
-                ;;
-            *)
-                search_for_replace=$(($search_for_replace - 1));
-                ;;
+            -*) ;;
+            *) : $((search_for_replace -= 1));;
         esac
     else
         if [ "$add_compose_file" =  true ]; then
@@ -301,10 +298,7 @@ done
 
 # If Docker and not rootless, then we have some work to do.
 if [ "$CONTAINER_ENGINE" = "docker" ] && ! docker info -f '{{println .SecurityOptions}}' | grep 'rootless' 1>/dev/null; then
-    HOST_MAPPED_GROUP="$(id -gn)";
-    HOST_MAPPED_GID="$(id -g)";
-    HOST_MAPPED_USER="$(id -un)";
-    HOST_MAPPED_UID="$(id -u)";
+    HOST_USER="$(id -un):$(id -u):$(id -gn):$(id -g)";
 
     # Loop through the containers created by this command.
     while read temp_container_id; do
@@ -316,10 +310,7 @@ if [ "$CONTAINER_ENGINE" = "docker" ] && ! docker info -f '{{println .SecurityOp
 $(container_create "$@")
 EOF
 else
-    HOST_MAPPED_GROUP='root';
-    HOST_MAPPED_GID=0;
-    HOST_MAPPED_USER='root';
-    HOST_MAPPED_UID=0;
+    HOST_USER='root:0:root:0';
 fi
 
 # Restore the args list we may have mangled before, and insert runtime arguments.
@@ -340,9 +331,9 @@ for arg do
                     set -- "$@" "$arg";
                 fi
 
-                set -- "$@" '-e' "HOST_MAPPED_GID=$HOST_MAPPED_GID" '-e' "HOST_MAPPED_GROUP=$HOST_MAPPED_GROUP" '-e' "HOST_MAPPED_UID=$HOST_MAPPED_UID" '-e' "HOST_MAPPED_USER=$HOST_MAPPED_USER";
+                set -- "$@" '-e' "HOST_USER=${HOST_USER}";
                 if [ -n "$CHOWN_LIST" ]; then
-                    set -- "$@" '-e' "CHOWN_LIST=$CHOWN_LIST";
+                    set -- "$@" '-e' "CHOWN_LIST=${CHOWN_LIST}";
                 fi
 
                 search_for_insert=0;
@@ -354,21 +345,15 @@ for arg do
 
         # Decrement for non-option arguments.
         case $arg in
-            -*)
-                ;;
-            *)
-                search_for_insert=$(($search_for_insert - 1));
-                ;;
+            -*) ;;
+            *) : $((search_for_insert -= 1));;
         esac
     else
         set -- "$@" "$arg";
     fi
 done
 
-export HOST_MAPPED_GROUP;
-export HOST_MAPPED_GID;
-export HOST_MAPPED_USER;
-export HOST_MAPPED_UID;
+export HOST_USER;
 if [ -n "$CHOWN_LIST" ]; then
     export CHOWN_LIST;
 fi

--- a/test/cli-volume-container-test
+++ b/test/cli-volume-container-test
@@ -3,7 +3,7 @@ THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)";
 . "$THIS_SCRIPT_DIR/../scripts/test-utilities";
 
 $COMPOSE_ENGINE build;
-./user-mirror $COMPOSE_ENGINE run --volume /mnt/volumes/volume/ --rm sh -c '\
+./user-mirror $COMPOSE_ENGINE run --env USER_MIRROR_CHOWN_LIST=/mnt/volumes/volume --volume /mnt/volumes/volume/ --rm sh -c '\
     [ "$(stat -c %u:%g /mnt/volumes/volume/)" = "$(id -u):$(id -g)" ] || \
     (echo "Permissions for /mnt/volumes/volume/ ($(stat -c %u:%g /mnt/volumes/volume/)) != UID:GID ($(id -u):$(id -g))" >&2 && false) \
     ';

--- a/test/cli-volume-container-test
+++ b/test/cli-volume-container-test
@@ -3,7 +3,7 @@ THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)";
 . "$THIS_SCRIPT_DIR/../scripts/test-utilities";
 
 $COMPOSE_ENGINE build;
-./user-mirror $COMPOSE_ENGINE run --volume /mnt/volumes/volume/ --env CHOWN_LIST='/mnt/volumes/volume/' --rm sh -c '\
+./user-mirror $COMPOSE_ENGINE run --volume /mnt/volumes/volume/ --rm sh -c '\
     [ "$(stat -c %u:%g /mnt/volumes/volume/)" = "$(id -u):$(id -g)" ] || \
     (echo "Permissions for /mnt/volumes/volume/ ($(stat -c %u:%g /mnt/volumes/volume/)) != UID:GID ($(id -u):$(id -g))" >&2 && false) \
     ';

--- a/test/cli-volume-container-test
+++ b/test/cli-volume-container-test
@@ -3,7 +3,7 @@ THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)";
 . "$THIS_SCRIPT_DIR/../scripts/test-utilities";
 
 $COMPOSE_ENGINE build;
-./user-mirror $COMPOSE_ENGINE run --env USER_MIRROR_CHOWN_LIST=/mnt/volumes/volume --volume /mnt/volumes/volume/ --rm sh -c '\
+./user-mirror $COMPOSE_ENGINE run --env USER_MIRROR_CHOWN_LIST=/mnt/volumes/volume/ --volume /mnt/volumes/volume/ --rm sh -c '\
     [ "$(stat -c %u:%g /mnt/volumes/volume/)" = "$(id -u):$(id -g)" ] || \
     (echo "Permissions for /mnt/volumes/volume/ ($(stat -c %u:%g /mnt/volumes/volume/)) != UID:GID ($(id -u):$(id -g))" >&2 && false) \
     ';

--- a/test/cli-volume-host-test
+++ b/test/cli-volume-host-test
@@ -4,7 +4,7 @@ THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)";
 
 $COMPOSE_ENGINE build;
 mkdir volume
-./user-mirror $COMPOSE_ENGINE run --rm --volume /docker-user-mirror/volume/ --env CHOWN_LIST='/docker-user-mirror/volume/' sh -c 'true';
+./user-mirror $COMPOSE_ENGINE run --rm --volume /docker-user-mirror/volume/ - sh -c 'true';
 
 # Test directory exists
 if ! [ -d volume ]; then

--- a/test/cli-volume-host-test
+++ b/test/cli-volume-host-test
@@ -4,7 +4,7 @@ THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)";
 
 $COMPOSE_ENGINE build;
 mkdir volume
-./user-mirror $COMPOSE_ENGINE run --env USER_MIRROR_CHOWN_LIST=/mnt/volumes/volume --rm --volume /docker-user-mirror/volume/ sh -c 'true';
+./user-mirror $COMPOSE_ENGINE run --env USER_MIRROR_CHOWN_LIST=/mnt/volumes/volume/ --rm --volume /docker-user-mirror/volume/ sh -c 'true';
 
 # Test directory exists
 if ! [ -d volume ]; then

--- a/test/cli-volume-host-test
+++ b/test/cli-volume-host-test
@@ -4,7 +4,7 @@ THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)";
 
 $COMPOSE_ENGINE build;
 mkdir volume
-./user-mirror $COMPOSE_ENGINE run --env USER_MIRROR_CHOWN_LIST=/mnt/volumes/volume/ --rm --volume /docker-user-mirror/volume/ sh -c 'true';
+./user-mirror $COMPOSE_ENGINE run --env USER_MIRROR_CHOWN_LIST=/docker-user-mirror/volume/ --rm --volume /docker-user-mirror/volume/ sh -c 'true';
 
 # Test directory exists
 if ! [ -d volume ]; then

--- a/test/cli-volume-host-test
+++ b/test/cli-volume-host-test
@@ -4,7 +4,7 @@ THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)";
 
 $COMPOSE_ENGINE build;
 mkdir volume
-./user-mirror $COMPOSE_ENGINE run --rm --volume /docker-user-mirror/volume/ - sh -c 'true';
+./user-mirror $COMPOSE_ENGINE run --env USER_MIRROR_CHOWN_LIST=/mnt/volumes/volume --rm --volume /docker-user-mirror/volume/ - sh -c 'true';
 
 # Test directory exists
 if ! [ -d volume ]; then

--- a/test/cli-volume-host-test
+++ b/test/cli-volume-host-test
@@ -4,7 +4,7 @@ THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)";
 
 $COMPOSE_ENGINE build;
 mkdir volume
-./user-mirror $COMPOSE_ENGINE run --env USER_MIRROR_CHOWN_LIST=/mnt/volumes/volume --rm --volume /docker-user-mirror/volume/ - sh -c 'true';
+./user-mirror $COMPOSE_ENGINE run --env USER_MIRROR_CHOWN_LIST=/mnt/volumes/volume --rm --volume /docker-user-mirror/volume/ sh -c 'true';
 
 # Test directory exists
 if ! [ -d volume ]; then


### PR DESCRIPTION
## What are these changes?
* Merge `HOST_MAPPED_` environment variables into `HOST_USER` separated by `:`.
* Add default comment when creating the mirrored user.
* Compress decrement expressions.
* Use `export` instead of setting environment variables inline.

## Why are these changes being made?
This change resolves #79.