### PR TITLE
Improve command parsing

### DIFF
--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -206,7 +206,7 @@ if [ "$o_setup" = true ]; then
                 ppc64le) dpkgArch='ppc64el' ;;
                 riscv64 | s390x) dpkgArch="$unameArch" ;;
                 x86_64) dpkgArch='amd64' ;;
-                *) echo >&2 "error: unknown/unsupported architecture '$unameArch'"; exit 1 ;;
+                *) printf 'error: unknown/unsupported architecture: %s\n' "$unameArch" >&2; exit 1;;
             esac
 
             mkdir -p /usr/local/bin/;
@@ -228,7 +228,7 @@ else
     set -eC;
 
     if [ -z "$USER_MIRROR_HOST_USER" ]; then
-        printf 'USER_MIRROR_HOST_USER is unset\n' >&2;
+        echo 'USER_MIRROR_HOST_USER is unset' >&2;
         guard_failure=true;
     fi
 
@@ -236,9 +236,9 @@ else
         exit 1;
     fi
 
-    echo "USER_MIRROR_CAPABILITIES=${USER_MIRROR_CAPABILITIES}" >&3;
-    echo "USER_MIRROR_HOST_USER=${USER_MIRROR_HOST_USER}" >&3;
-    echo "USER_MIRROR_SERVICE_NAME=${USER_MIRROR_SERVICE_NAME}" >&3;
+    printf 'USER_MIRROR_CAPABILITIES=%s\n' "$USER_MIRROR_CAPABILITIES" >&3;
+    printf 'USER_MIRROR_HOST_USER=%s\n' "$USER_MIRROR_HOST_USER" >&3;
+    printf 'USER_MIRROR_SERVICE_NAME=%s\n' "$USER_MIRROR_SERVICE_NAME" >&3;
 
     host_user_name="$(extract_index "$USER_MIRROR_HOST_USER" 0 ':')";
     host_user_id="$(extract_index "$USER_MIRROR_HOST_USER" 1 ':')";
@@ -251,7 +251,7 @@ else
 
         uid_username="$(awk -F: "\$3 == ${host_user_id} {print \$1}" /etc/passwd)";
         if id -u "$uid_username" >/dev/null 2>&1; then
-            echo "Removing user matching UID ${host_user_id}: $(print_user "$uid_username")" >&3;
+            printf 'Removing user matching UID %s: %s\n' "$host_user_id" "$(print_user "$uid_username")" >&3;
             if command -v userdel >/dev/null; then
                 userdel "$uid_username";
             else
@@ -271,7 +271,7 @@ else
         else
             adduser -D -g 'Mirrored Host User' -G "$gid_groupname" -s "$SHELL" -u "$host_user_id" "$host_user_name" 2>&4;
         fi
-        echo "Created user: $(print_user "$host_user_name")" >&3;
+        printf 'Created user: %s\n' "$(print_user "$host_user_name")" >&3;
 
         export HOME="/home/${host_user_name}";
     else

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -24,7 +24,7 @@ extract_index() (
     str="$1";
     count="${2:-0}";
     delimiter="${3:- }";
-    while [ $count -gt 0 ]; do
+    while [ "$count" -gt 0 ]; do
         : $((count -= 1));
         case "$str" in
             *${delimiter}*) str="${str#*${delimiter}}";;
@@ -139,7 +139,7 @@ version_to_release_tag() {
 
 # Parse options.
 while [ $# -gt 0 ]; do
-    case $1 in
+    case "$1" in
         --setup)
             o_setup=true;
             ;;
@@ -184,14 +184,14 @@ if [ "$o_setup" = true ]; then
 
         # Attempt to install setpriv with apk.
         if (apk update && apk -s add setpriv) >/dev/null 2>&1; then
-            apk add --no-cache "setpriv>=$SETPRIV_VERSION";
+            apk add --no-cache "setpriv>=${SETPRIV_VERSION}";
             hash -r;
             check_setpriv;
             echo 'setpriv installed!';
 
         # Attempt to install setpriv from util-linux with apt-get.
         elif (apt-get update && apt-get install --dry-run util-linux) >/dev/null 2>&1; then
-            apt-get satisfy --no-install-recommends -y "util-linux (>=$UTIL_LINUX_VERSION)";
+            apt-get satisfy --no-install-recommends -y "util-linux (>=${UTIL_LINUX_VERSION})";
             hash -r;
             check_setpriv;
             echo 'setpriv installed!';
@@ -212,8 +212,8 @@ if [ "$o_setup" = true ]; then
             esac
 
             mkdir -p /usr/local/bin/;
-            wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch";
-            wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc";
+            wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}";
+            wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc";
 
             GNUPGHOME="$(mktemp -d)";
             if command -v gpg >/dev/null; then
@@ -253,7 +253,7 @@ else
 
         uid_username="$(awk -F: "\$3 == ${host_user_id} {print \$1}" /etc/passwd)";
         if id -u "$uid_username" >/dev/null 2>&1; then
-            echo "Removing user matching UID ${host_user_id}: $(print_user $uid_username)" >&3;
+            echo "Removing user matching UID ${host_user_id}: $(print_user "$uid_username")" >&3;
             if command -v userdel >/dev/null; then
                 userdel "$uid_username";
             else
@@ -289,7 +289,7 @@ else
             continue;
         fi
 
-        case $service_name in
+        case "$service_name" in
             /*)
                 chown_path="$service_name";
                 unset service_name;
@@ -324,7 +324,7 @@ EOF
 
     # Execute using $HOST_MAPPED_UID.
     if check_setpriv >/dev/null 2>&1; then
-        echo "exec setpriv --bounding-set \"$capabilities\" --init-groups --no-new-privs --reuid=${host_user_id} --regid=${host_user_gid} ..." >&3;
+        echo "exec setpriv --bounding-set \"${capabilities}\" --init-groups --no-new-privs --reuid=${host_user_id} --regid=${host_user_gid} ..." >&3;
         exec setpriv --bounding-set "$capabilities" --init-groups --no-new-privs --reuid=${host_user_id} --regid=${host_user_gid} "$@";
     elif command -v gosu >/dev/null; then
         echo "exec gosu \"${host_user_id}:${host_user_gid}\" ..." >&3;

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -151,7 +151,7 @@ while [ $# -gt 0 ]; do
             exec 4>&2;
             ;;
         --version)
-            echo "Version: ${VERSION}";
+            printf 'Version: %s\n' "$VERSION";
             exit 0;
             ;;
         -y|--yes)

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -161,9 +161,7 @@ while [ $# -gt 0 ]; do
             shift;
             break;
             ;;
-        *)
-            break;
-            ;;
+        *) break;;
     esac
     shift;
 done

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -38,9 +38,9 @@ extract_index() (
 # Args: release filename, output filename, release tag (defaults to latest release it not provided)
 download_file() {
     if [ $# -eq 3 ]; then
-        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/download/$3/$1";
+        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/download/${3}/${1}";
     elif [ $# -eq 2 ]; then
-        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/$1";
+        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/${1}";
     else
         echo 'Expected at least two arguments.' >&2;
         return 1;
@@ -66,7 +66,7 @@ get_release_version() {
     if [ $# -eq 0 ]; then
         response="$(curl -Ls -w '\n%{http_code}' 'https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/version')";
     else
-        response="$(curl -Ls -w '\n%{http_code}' "https://github.com/AJGranowski/docker-user-mirror/releases/download/$1/version")";
+        response="$(curl -Ls -w '\n%{http_code}' "https://github.com/AJGranowski/docker-user-mirror/releases/download/${1}/version")";
     fi
 
     case "$(echo "$response" | tail -1)" in
@@ -78,12 +78,12 @@ get_release_version() {
 }
 
 print_user() {
-    grep -e "^$1:" /etc/passwd;
+    grep -e "^${1}:" /etc/passwd;
 }
 
 # Query GitHub to check if a release tag exists.
 release_tag_exists() {
-    case "$(curl -Ls -o /dev/null -w '%{http_code}' "https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/tags/$1")" in
+    case "$(curl -Ls -o /dev/null -w '%{http_code}' "https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/tags/${1}")" in
         2*) true;;
         *) false;;
     esac
@@ -107,8 +107,8 @@ update() {
         fi
     fi
 
-    echo "    Current version: $VERSION";
-    echo "    Latest version:  $latest_version";
+    printf '    Current version: %s\n' "$VERSION";
+    printf '    Latest version:  %s\n' "$latest_version";
 
     if [ "$VERSION" = "$latest_version" ]; then
         return 0;
@@ -117,7 +117,7 @@ update() {
     if [ "$o_yes" != true ]; then
         echo '\nInstall the update? (y/n)';
         read yn;
-        case $yn in
+        case "$yn" in
             y*) ;;
             n*) return 0;;
         esac
@@ -125,7 +125,7 @@ update() {
 
     echo 'Installing update...';
     download_file 'entrypoint' "${0}.tmp";
-    mv "${0}.tmp" "$0" && chmod +x "$0" && echo "${latest_version} installed!"; exit 0;
+    mv "${0}.tmp" "$0" && chmod +x "$0" && printf '%s installed!\n' "$latest_version"; exit 0;
 }
 
 # Convert "$VERSION" to "release-**" format.

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -7,9 +7,24 @@ VERSION='development';
 # Create container(s) and return the container ID(s).
 container_create() {
     if [ "$COMMAND_TYPE" = 'compose' ]; then
-        # For compose commands, we just need to create containers used in the command.
-        # TODO: Be selective when creating containers. # https://github.com/AJGranowski/docker-user-mirror/issues/83
-        $COMPOSE_ENGINE --progress quiet create >/dev/null 2>&1;
+        # For compose commands, we just need to create the containers used in the command.
+        # TODO: Be selective when creating containers. https://github.com/AJGranowski/docker-user-mirror/issues/83
+        for arg do
+            if [ "$is_file" = true ]; then
+                unset is_file;
+                if [ -z "$compose_configuration_files" ]; then
+                    compose_configuration_files="-f ${arg}";
+                else
+                    compose_configuration_files="${compose_configuration_files} -f ${arg}";
+                fi
+            else
+                case "$arg" in
+                    -f|--file) is_file=true;;
+                esac
+            fi
+        done
+
+        $COMPOSE_ENGINE --progress quiet $compose_configuration_files create >/dev/null 2>&1;
         $COMPOSE_ENGINE --progress quiet ps --status created --format '{{.ID}}';
     elif [ "$COMMAND_TYPE" = 'container' ]; then
         # For a non-compose commands, we can just change "exec" and "run" to "create", and then use that new command

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -7,18 +7,14 @@ VERSION='development';
 # Create container(s) and return the container ID(s).
 container_create() {
     if [ "$COMMAND_TYPE" = 'compose' ]; then
-        # For compose commands, we just to create containers used in the command. No need to worry about forwarding arguments.
-        # For example:
-        # docker compose up => docker compose create
-        # docker compose up service1 service2 => docker compose create service1 service2
-        # docker compose run service1 => docker compose create service1
+        # For compose commands, we just need to create containers used in the command.
+        # TODO: Be selective when creating containers. # https://github.com/AJGranowski/docker-user-mirror/issues/83
         $COMPOSE_ENGINE --progress quiet create >/dev/null 2>&1;
-        $COMPOSE_ENGINE --progress quiet ps -a --status created --format '{{.ID}}';
+        $COMPOSE_ENGINE --progress quiet ps --status created --format '{{.ID}}';
     elif [ "$COMMAND_TYPE" = 'container' ]; then
-        # For container commands, we just replace exec and run with create and then run the command.
-        # To get the arguments from a non-compose invocation, we'll change "exec" and "run" to "create", and then use that new
-        #   command string to create (but not start) a container for parsing. This is a workaround for POSIX shell only having
-        #   one array object (the argument list).
+        # For a non-compose commands, we can just change "exec" and "run" to "create", and then use that new command
+        #   to create (but not start) a container for parsing. We're modifying the argument list since that's the only
+        #   array supported in POSIX shell.
         first_iteration=true;
         index=0;
         search_for_replace=true;

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -353,12 +353,7 @@ for arg do
     if [ "$search_for_insert" -gt 0 ]; then
         case "$arg" in
             create|exec|run)
-                if [ -n "$REPLACED_COMMAND" ]; then
-                    set -- "$@" "$REPLACED_COMMAND";
-                else
-                    set -- "$@" "$arg";
-                fi
-
+                set -- "$@" "$arg";
                 set -- "$@" '-e' "USER_MIRROR_HOST_USER=${USER_MIRROR_HOST_USER}";
                 if [ -n "$USER_MIRROR_CHOWN_LIST" ]; then
                     set -- "$@" '-e' "USER_MIRROR_CHOWN_LIST=${USER_MIRROR_CHOWN_LIST}";

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -6,14 +6,70 @@ VERSION='development';
 
 # Create container(s) and return the container ID(s).
 container_create() {
-    if [ -n "$REPLACED_COMMAND" ]; then
-        "$@";
-    elif [ -n "$COMPOSE_FILES" ]; then
-        $COMPOSE_ENGINE --progress quiet --file "$COMPOSE_FILES" create >/dev/null 2>&1;
-        $COMPOSE_ENGINE --progress quiet --file "$COMPOSE_FILES" ps -a --status created --format '{{.ID}}';
-    else
+    if [ "$COMMAND_TYPE" = 'compose' ]; then
+        # For compose commands, we just to create containers used in the command. No need to worry about forwarding arguments.
+        # For example:
+        # docker compose up => docker compose create
+        # docker compose up service1 service2 => docker compose create service1 service2
+        # docker compose run service1 => docker compose create service1
         $COMPOSE_ENGINE --progress quiet create >/dev/null 2>&1;
         $COMPOSE_ENGINE --progress quiet ps -a --status created --format '{{.ID}}';
+    elif [ "$COMMAND_TYPE" = 'container' ]; then
+        # For container commands, we just replace exec and run with create and then run the command.
+        # To get the arguments from a non-compose invocation, we'll change "exec" and "run" to "create", and then use that new
+        #   command string to create (but not start) a container for parsing. This is a workaround for POSIX shell only having
+        #   one array object (the argument list).
+        first_iteration=true;
+        index=0;
+        search_for_replace=true;
+        for arg do
+            if [ "$first_iteration" = true ]; then
+                unset first_iteration;
+                shift $#;
+            fi
+
+            if [ "$search_for_replace" = true ]; then
+                case "$arg" in
+                    exec|run)
+                        replaced_command="$arg";
+                        replaced_command_index="$index";
+                        set -- "$@" "create";
+                        unset search_for_replace;
+                        ;;
+                    *)
+                        set -- "$@" "$arg";
+                        ;;
+                esac
+            else
+                set -- "$@" "$arg";
+            fi
+
+            : $((index += 1));
+        done
+
+        "$@";
+
+        if [ -n "$replaced_command" ] && [ -n "$replaced_command_index" ]; then
+            first_iteration=true;
+            index=0;
+            for arg do
+                if [ "$first_iteration" = true ]; then
+                    unset first_iteration;
+                    shift $#;
+                fi
+
+                if [ "$index" -eq "$replaced_command_index" ]; then
+                    set -- "$@" "$replaced_command";
+                else
+                    set -- "$@" "$arg";
+                fi
+
+                : $((index += 1));
+            done
+        fi
+    else
+        printf 'Unknown COMMAND_TYPE state: %s\n' "$COMMAND_TYPE" >&2;
+        exit 1;
     fi
 }
 
@@ -21,9 +77,9 @@ container_create() {
 # Args: release filename, output filename, release tag (defaults to latest release it not provided)
 download_file() {
     if [ $# -eq 3 ]; then
-        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/download/$3/$1";
+        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/download/${3}/${1}";
     elif [ $# -eq 2 ]; then
-        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/$1";
+        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/${1}";
     else
         echo 'Expected at least two arguments.' >&2;
         return 1;
@@ -49,7 +105,7 @@ get_release_version() {
     if [ $# -eq 0 ]; then
         response="$(curl -Ls -w '\n%{http_code}' 'https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/version')";
     else
-        response="$(curl -Ls -w '\n%{http_code}' "https://github.com/AJGranowski/docker-user-mirror/releases/download/$1/version")";
+        response="$(curl -Ls -w '\n%{http_code}' "https://github.com/AJGranowski/docker-user-mirror/releases/download/${1}/version")";
     fi
 
     case "$(echo "$response" | tail -1)" in
@@ -64,11 +120,11 @@ get_release_version() {
 # Args: container ID (retrieved from container_create)
 prepare_environment() {
     # Grab the USER_MIRROR_SERVICE_NAME environment variable if it exists.
-    service_name="$($CONTAINER_ENGINE inspect --format '{{range .Config.Env}}{{if and (gt (len .) 13) (eq (slice . 0 13) "USER_MIRROR_SERVICE_NAME=")}}{{slice . 13}}{{end}}{{end}}' "$1")";
+    service_name="$($CONTAINER_ENGINE inspect --format '{{range .Config.Env}}{{if and (gt (len .) 25) (eq (slice . 0 25) "USER_MIRROR_SERVICE_NAME=")}}{{slice . 25}}{{end}}{{end}}' "$1")";
 
     # Create a list of all read/write mount destinations so they can be chown'd in the container at runtime.
     USER_MIRROR_CHOWN_LIST="$USER_MIRROR_CHOWN_LIST
-$($CONTAINER_ENGINE inspect --format "{{range .Mounts}}{{if .RW}}{{println \"$service_name\"}}{{println .Destination}}{{end}}{{end}}" "$1")";
+$($CONTAINER_ENGINE inspect --format "{{range .Mounts}}{{if .RW}}{{println \"${service_name}\"}}{{println .Destination}}{{end}}{{end}}" "$1")";
 
     # Loop through bind mounts that have a non-empty mode (`create_host_path: true` sets this), and mkdir those source paths on the host.
     while read create_path; do
@@ -121,7 +177,7 @@ EOF
 
 # Query GitHub to check if a release tag exists.
 release_tag_exists() {
-    case "$(curl -Ls -o /dev/null -w '%{http_code}' "https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/tags/$1")" in
+    case "$(curl -Ls -o /dev/null -w '%{http_code}' "https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/tags/${1}")" in
         2*) true;;
         *) false;;
     esac
@@ -145,8 +201,8 @@ update() {
         fi
     fi
 
-    echo "    Current version: $VERSION";
-    echo "    Latest version:  $latest_version";
+    printf '    Current version: %s\n' "$VERSION";
+    printf '    Latest version:  %s\n' "$latest_version";
 
     if [ "$VERSION" = "$latest_version" ]; then
         return 0;
@@ -155,7 +211,7 @@ update() {
     if [ "$o_yes" != true ]; then
         echo '\nInstall the update? (y/n)';
         read yn;
-        case $yn in
+        case "$yn" in
             y*) ;;
             n*) return 0;;
         esac
@@ -163,7 +219,7 @@ update() {
 
     echo 'Installing update...';
     download_file 'user-mirror' "${0}.tmp";
-    mv "${0}.tmp" "$0" && chmod +x "$0" && echo "${latest_version} installed!"; exit 0;
+    mv "${0}.tmp" "$0" && chmod +x "$0" && printf '%s installed!\n' "$latest_version"; exit 0;
 }
 
 # Convert "$VERSION" to "release-**" format.
@@ -177,7 +233,7 @@ version_to_release_tag() {
 
 # Parse options.
 while [ $# -gt 0 ]; do
-    case $1 in
+    case "$1" in
         --docker)
             COMPOSE_ENGINE='docker compose';
             CONTAINER_ENGINE='docker';
@@ -198,7 +254,7 @@ while [ $# -gt 0 ]; do
             o_update=true;
             ;;
         --version)
-            echo "Version: ${VERSION}";
+            printf 'Cersion: %s\n' "$VERSION";
             exit 0;
             ;;
         -y|--yes)
@@ -209,7 +265,7 @@ while [ $# -gt 0 ]; do
             break;
             ;;
         -*)
-            printf 'Unknown option %s\n' $1 >&2;
+            printf 'Unknown option %s\n' "$1" >&2;
             exit 1;
             ;;
         *)
@@ -229,7 +285,7 @@ fi
 
 # Parse the command if no engine declared.
 if [ -z "$COMPOSE_ENGINE" ] || [ -z "$CONTAINER_ENGINE" ]; then
-    case $1 in
+    case "$1" in
         docker-compose)
             COMPOSE_ENGINE='docker-compose';
             CONTAINER_ENGINE='docker';
@@ -249,52 +305,24 @@ if [ -z "$COMPOSE_ENGINE" ] || [ -z "$CONTAINER_ENGINE" ]; then
     esac
 fi
 
-# To get the arguments from a non-compose invocation, we'll change "exec" and "run" to "create", and then use that new
-#   command string to create (but not start) a container for parsing. This is a workaround for POSIX shell only having
-#   one array object (the argument list).
-COMPOSE_FILES="";
-add_compose_file=false;
-first_iteration=true;
-search_for_replace=4;
+# Duck type the command
 for arg do
-    if [ "$first_iteration" = true ]; then
-        unset first_iteration;
-        shift $#;
-    fi
-
-    if [ $search_for_replace -gt 0 ]; then
-        case $arg in
-            compose)
-                set -- "$@" "$arg";
-                search_for_replace=0;
-                ;;
-            run)
-                REPLACED_COMMAND="$arg";
-                set -- "$@" "create";
-                search_for_replace=0;
-                ;;
-            *)
-                set -- "$@" "$arg";
-                ;;
-        esac
-
-        # Decrement for non-option arguments.
-        case $arg in
-            -*) ;;
-            *) : $((search_for_replace -= 1));;
-        esac
-    else
-        if [ "$add_compose_file" =  true ]; then
-            unset add_compose_file;
-            COMPOSE_FILES="$arg";
-        else
-            case $arg in
-                -f|--file) add_compose_file=true;;
-            esac
-        fi
-        set -- "$@" "$arg";
-    fi
+    case "$arg" in
+        compose|up)
+            COMMAND_TYPE='compose';
+            break;
+            ;;
+        create|exec|run)
+            COMMAND_TYPE='container';
+            break;
+            ;;
+    esac
 done
+
+if [ -z "$COMMAND_TYPE" ]; then
+    exec "$@";
+    exit 0;
+fi
 
 # If Docker and not rootless, then we have some work to do.
 if [ "$CONTAINER_ENGINE" = "docker" ] && ! docker info -f '{{println .SecurityOptions}}' | grep 'rootless' 1>/dev/null; then
@@ -322,8 +350,8 @@ for arg do
         shift $#;
     fi
 
-    if [ $search_for_insert -gt 0 ]; then
-        case $arg in
+    if [ "$search_for_insert" -gt 0 ]; then
+        case "$arg" in
             create|exec|run)
                 if [ -n "$REPLACED_COMMAND" ]; then
                     set -- "$@" "$REPLACED_COMMAND";
@@ -344,7 +372,7 @@ for arg do
         esac
 
         # Decrement for non-option arguments.
-        case $arg in
+        case "$arg" in
             -*) ;;
             *) : $((search_for_insert -= 1));;
         esac

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -47,9 +47,7 @@ container_create() {
                         set -- "$@" "create";
                         unset search_for_replace;
                         ;;
-                    *)
-                        set -- "$@" "$arg";
-                        ;;
+                    *) set -- "$@" "$arg";;
                 esac
             else
                 set -- "$@" "$arg";
@@ -279,9 +277,7 @@ while [ $# -gt 0 ]; do
             printf 'Unknown option %s\n' "$1" >&2;
             exit 1;
             ;;
-        *)
-            break;
-            ;;
+        *) break;;
     esac
     shift;
 done
@@ -372,9 +368,7 @@ for arg do
 
                 search_for_insert=0;
                 ;;
-            *)
-                set -- "$@" "$arg";
-                ;;
+            *) set -- "$@" "$arg";;
         esac
 
         # Decrement for non-option arguments.

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -308,7 +308,7 @@ for arg do
             COMMAND_TYPE='compose';
             break;
             ;;
-        create|exec|run)
+        container|create|exec|run)
             COMMAND_TYPE='container';
             break;
             ;;

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -254,7 +254,7 @@ while [ $# -gt 0 ]; do
             o_update=true;
             ;;
         --version)
-            printf 'Cersion: %s\n' "$VERSION";
+            printf 'Version: %s\n' "$VERSION";
             exit 0;
             ;;
         -y|--yes)


### PR DESCRIPTION
## What are these changes?
* Split container and compose command parsing.
* Replace `echo` with `printf` when using variables.
* Wrap variables with curly braces if they're not alone in a string.

## Why are these changes being made?
My previous assumption of just being able to change `run` to `create` in order to parse mount information [was wrong](https://github.com/AJGranowski/docker-user-mirror/issues/82). This change updates that understanding by parsing `compose` and `container` commands separately.