### PR TITLE
Be more selective when creating and removing containers

### DIFF
--- a/src/user-mirror
+++ b/src/user-mirror
@@ -69,7 +69,7 @@ EOF
 
         if [ "$create_all_containers" = true ]; then
             $COMPOSE_ENGINE --progress quiet $compose_configuration_files create >/dev/null;
-            $COMPOSE_ENGINE ps --status created;
+            $COMPOSE_ENGINE ps --status created --format '{{.ID}}';
         fi
     elif [ "$COMMAND_TYPE" = 'container' ]; then
         # For a non-compose commands, we can just change "exec" and "run" to "create", and then use that new command

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -7,9 +7,14 @@ VERSION='development';
 # Create container(s) and return the container ID(s).
 container_create() {
     if [ "$COMMAND_TYPE" = 'compose' ]; then
-        # For compose commands, we just need to create the containers used in the command.
-        # TODO: Be selective when creating containers. https://github.com/AJGranowski/docker-user-mirror/issues/83
+        # For compose commands, we don't need to worry about preserving options when creating containers.
+        search_limit=3;
+        skip_counter=0;
         for arg do
+            if [ "$search_limit" -le 0 ]; then
+                break;
+            fi
+
             if [ "$is_file" = true ]; then
                 unset is_file;
                 if [ -z "$compose_configuration_files" ]; then
@@ -20,19 +25,54 @@ container_create() {
             else
                 case "$arg" in
                     -f|--file) is_file=true;;
+                    run)
+                        is_run_command=true;
+                        break;
+                        ;;
+                esac
+
+                case "$arg" in
+                    -*) : $((search_limit += 2));;
                 esac
             fi
+
+            : $((search_limit -= 1));
+            : $((skip_counter += 1));
         done
 
-        $COMPOSE_ENGINE --progress quiet $compose_configuration_files create >/dev/null 2>&1;
-        $COMPOSE_ENGINE --progress quiet ps --status created --format '{{.ID}}';
+        for arg do
+            if [ "$skip_counter" -gt 0 ]; then
+                : $((skip_counter -= 1));
+                continue;
+            fi
+
+            if [ "$should_break" = true ]; then
+                break;
+            fi
+
+            while read service; do
+                if [ "$arg" = "$service" ]; then
+                    $COMPOSE_ENGINE --progress quiet $compose_configuration_files create "$service" >/dev/null;
+                    $COMPOSE_ENGINE ps -a --format "{{if eq .Service \"$service\"}}{{.ID}}{{end}}";
+
+                    if [ "$is_run_command" = true ]; then
+                        should_break=true;
+                        break;
+                    fi
+                fi
+            done <<EOF
+$(docker compose config --services)
+EOF
+        done
     elif [ "$COMMAND_TYPE" = 'container' ]; then
         # For a non-compose commands, we can just change "exec" and "run" to "create", and then use that new command
         #   to create (but not start) a container for parsing. We're modifying the argument list since that's the only
         #   array supported in POSIX shell.
+        abort=true;
         first_iteration=true;
         index=0;
         search_for_replace=true;
+        search_limit=3;
         for arg do
             if [ "$first_iteration" = true ]; then
                 unset first_iteration;
@@ -40,21 +80,40 @@ container_create() {
             fi
 
             if [ "$search_for_replace" = true ]; then
+                if [ "$search_limit" -le 0 ]; then
+                    break;
+                fi
+
                 case "$arg" in
                     exec|run)
                         replaced_command="$arg";
                         replaced_command_index="$index";
                         set -- "$@" "create";
+                        unset abort;
                         unset search_for_replace;
+                        ;;
+                    create)
+                        unset abort;
+                        set -- "$@" "$arg";
                         ;;
                     *) set -- "$@" "$arg";;
                 esac
+
+                case "$arg" in
+                    -*) : $((search_limit += 2));;
+                esac
+
+                : $((index += 1));
+                : $((search_limit -= 1));
             else
                 set -- "$@" "$arg";
             fi
-
-            : $((index += 1));
         done
+
+        if [ "$abort" = true ]; then
+            echo '[user-mirror]: Unable to create container.' >&2;
+            exit 1;
+        fi
 
         "$@";
 
@@ -313,7 +372,12 @@ if [ -z "$COMPOSE_ENGINE" ] || [ -z "$CONTAINER_ENGINE" ]; then
 fi
 
 # Duck type the command
+search_limit=2;
 for arg do
+    if [ "$search_limit" -le 0 ]; then
+        break;
+    fi
+
     case "$arg" in
         compose|up)
             COMMAND_TYPE='compose';
@@ -323,12 +387,15 @@ for arg do
             COMMAND_TYPE='container';
             break;
             ;;
+        -*) : $((search_limit += 2));;
     esac
+
+    : $((search_limit -= 1));
 done
 
 if [ -z "$COMMAND_TYPE" ]; then
-    exec "$@";
-    exit 0;
+    echo '[user-mirror]: Unable to parse command. Aborting.' >&2;
+    exit 1;
 fi
 
 # If Docker and not rootless, then we have some work to do.
@@ -337,10 +404,16 @@ if [ "$CONTAINER_ENGINE" = "docker" ] && ! docker info -f '{{println .SecurityOp
 
     # Loop through the containers created by this command.
     while read temp_container_id; do
+        if [ -z "$temp_container_id" ]; then
+            continue;
+        fi
+
         prepare_environment "$temp_container_id"
 
         # Cleanup.
-        $CONTAINER_ENGINE container rm "$temp_container_id" >/dev/null 2>&1;
+        if [ "$(docker inspect --format '{{.State.Status}}' "$temp_container_id")" = 'created' ]; then
+            $CONTAINER_ENGINE container rm "$temp_container_id" >/dev/null;
+        fi
     done <<EOF
 $(container_create "$@")
 EOF

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -76,7 +76,6 @@ EOF
         # For a non-compose commands, we can just change "exec" and "run" to "create", and then use that new command
         #   to create (but not start) a container for parsing. We're modifying the argument list since that's the only
         #   array supported in POSIX shell.
-        abort=true;
         first_iteration=true;
         index=0;
         search_for_replace=true;
@@ -97,12 +96,11 @@ EOF
                         replaced_command="$arg";
                         replaced_command_index="$index";
                         set -- "$@" "create";
-                        unset abort;
                         unset search_for_replace;
                         ;;
                     create)
-                        unset abort;
                         set -- "$@" "$arg";
+                        unset search_for_replace;
                         ;;
                     *) set -- "$@" "$arg";;
                 esac
@@ -118,7 +116,7 @@ EOF
             fi
         done
 
-        if [ "$abort" = true ]; then
+        if [ "$search_for_replace" = true ]; then
             echo '[user-mirror]: Unable to create container.' >&2;
             exit 1;
         fi

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -40,6 +40,7 @@ container_create() {
             : $((skip_counter += 1));
         done
 
+        create_all_containers=true;
         for arg do
             if [ "$skip_counter" -gt 0 ]; then
                 : $((skip_counter -= 1));
@@ -52,6 +53,7 @@ container_create() {
 
             while read service; do
                 if [ "$arg" = "$service" ]; then
+                    unset create_all_containers;
                     $COMPOSE_ENGINE --progress quiet $compose_configuration_files create "$service" >/dev/null;
                     $COMPOSE_ENGINE ps -a --format "{{if eq .Service \"$service\"}}{{.ID}}{{end}}";
 
@@ -64,6 +66,11 @@ container_create() {
 $(docker compose config --services)
 EOF
         done
+
+        if [ "$create_all_containers" = true ]; then
+            $COMPOSE_ENGINE --progress quiet $compose_configuration_files create >/dev/null;
+            $COMPOSE_ENGINE ps --status created;
+        fi
     elif [ "$COMMAND_TYPE" = 'container' ]; then
         # For a non-compose commands, we can just change "exec" and "run" to "create", and then use that new command
         #   to create (but not start) a container for parsing. We're modifying the argument list since that's the only

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -47,7 +47,7 @@ container_create() {
                 continue;
             fi
 
-            if [ "$should_break" = true ]; then
+            if [ "$exit_loop" = true ]; then
                 break;
             fi
 
@@ -58,9 +58,10 @@ container_create() {
                     $COMPOSE_ENGINE ps -a --format "{{if eq .Service \"$service\"}}{{.ID}}{{end}}";
 
                     if [ "$is_run_command" = true ]; then
-                        should_break=true;
-                        break;
+                        exit_loop=true;
                     fi
+
+                    break;
                 fi
             done <<EOF
 $(docker compose config --services)


### PR DESCRIPTION
## What are these changes?
* Only remove "temp" containers if they're in the `created` state.
* Selectively create compose containers listed in the command.
* Limit command keyword searches.

## Why are these changes being made?
This change resolves #83 by iterating over the services listed in the compose file and comparing them against the services used in the command.

This change also hardens the script a bit by adding command keyword search limits, and failing faster (rather than attempting to continue).