### PR TITLE
CI/CD overhaul

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -146,6 +146,7 @@ jobs:
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
+          source: ./src
           workdir: src
 
       - name: Run Tests

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -145,7 +145,7 @@ jobs:
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
-          workdir: src
+          source: src
 
       - name: Run Tests
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -141,7 +141,6 @@ jobs:
           allow: |
             network.host
           builder: ${{ steps.setup-buildx-action.outputs.name }}
-          files: src/compose.yml
           load: true
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -146,6 +146,7 @@ jobs:
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
+          workdir: src
 
       - name: Run Tests
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -145,6 +145,7 @@ jobs:
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
+          source: .
 
       - name: Run Tests
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -141,13 +141,11 @@ jobs:
           allow: |
             network.host
           builder: ${{ steps.setup-buildx-action.outputs.name }}
-          files: 
-            ./compose.yml
-            src/compose.yml
           load: true
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
+          source: ./compose.yml
           workdir: ./src
 
       - name: Run Tests

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Validate Compose File
+        run: docker compose --file src/compose.yml config --quiet
+
       - name: Use Rootless Docker
         if: ${{ matrix.container-context == 'docker-rootless' }}
         uses: ScribeMD/rootless-docker@6bd157a512c2fafa4e0243a8aa87d964eb890886 # 0.2.2
@@ -142,6 +145,7 @@ jobs:
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
+          workdir: src
 
       - name: Run Tests
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -145,7 +145,7 @@ jobs:
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
-          source: ./compose.yml
+          source: compose.yml
           workdir: ./src
 
       - name: Run Tests

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -141,11 +141,11 @@ jobs:
           allow: |
             network.host
           builder: ${{ steps.setup-buildx-action.outputs.name }}
+          files: compose.yml
           load: true
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
-          source: ./src
           workdir: src
 
       - name: Run Tests

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -142,11 +142,16 @@ jobs:
             network.host
           builder: ${{ steps.setup-buildx-action.outputs.name }}
           load: true
+          files: |
+            alpine
+            busybox
+            debian
+            ubuntu
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
           source: .
-          workdir: ./src
+          workdir: ./images
 
       - name: Run Tests
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -135,78 +135,103 @@ jobs:
           chmod --changes +x ./make-release
           ./make-release
 
-  tag-for-release:
-    name: Tag for Release
-    runs-on: ubuntu-latest
-    needs: [workflow-filter, ci]
-    environment: elevated-workflow
-    concurrency:
-      group: tag-for-release
-
-    if: ${{ needs.workflow-filter.outputs.run-tag-for-release == 'true' }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:22
-            github.com:443
-
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-          filter: tree:0
-          ssh-key: ${{ secrets.ELEVATED_WORKFLOW_DEPLOY_KEY }}
-
-      - name: Get Latest Release Tag
-        run: echo "LATEST_RELEASE_TAG=$(git tag --list --sort=-v:refname release-* | head -1)" >> $GITHUB_ENV
-
-      - name: Increment Tag
-        id: increment-tag
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          LATEST_RELEASE_TAG: ${{ env.LATEST_RELEASE_TAG }}
-        with:
-          script: |
-            const latestReleaseTag = process.env.LATEST_RELEASE_TAG;
-            if (latestReleaseTag.length === 0) {
-              throw new Error("LATEST_RELEASE_TAG is empty!");
-            }
-
-            const incrementReleaseTag = latestReleaseTag.replace(/(\d+)([^\.]*)$/, (_, x, y) => (Number(x) + 1).toString() + y);
-            if (latestReleaseTag === incrementReleaseTag) {
-              throw new Error("Tag increment failed! (proposed tag matches LATEST_RELEASE_TAG)");
-            }
-
-            if (incrementReleaseTag.length < latestReleaseTag.length) {
-              throw new Error(`Tag increment failed! (proposed tag ${incrementReleaseTag} is shorter than ${latestReleaseTag}`);
-            }
-
-            return incrementReleaseTag;
-
-      - name: Tag Release
-        env:
-          NEW_RELEASE_TAG: ${{ fromJson(steps.increment-tag.outputs.result) }}
-        run: |
-          git config --global user.email "<>"
-          git config --global user.name "$RUNNER_NAME"
-          git tag -m "Automated Release" "$NEW_RELEASE_TAG";
-          git push origin tag "$NEW_RELEASE_TAG";
-
-  cd:
-    name: Continuous Deployment
+  ci-required-checks:
+    name: Required Checks
     runs-on: ubuntu-latest
     needs: ci
+    if: always()
+    steps:
+    - run: ${{ !contains(needs.*.result, 'failure') }}
+
+  release-bump:
+    name: Bump Release Tag
+    runs-on: ubuntu-latest
+    needs: [workflow-filter, ci, ci-required-checks]
+    environment: release-ruleset-bypass
+    concurrency:
+      group: release-bump
+    env:
+      RELEASE_REGEX: ^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+
+    if: ${{ github.ref == 'refs/heads/main' && needs.check-release-files.outputs.changed == 'true' }}
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      with:
+        disable-sudo: true
+        egress-policy: block
+        allowed-endpoints: >
+          api.github.com:443
+
+    - name: Generate Elevated Workflow token
+      uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+      id: release-ruleset-bypass-token
+      with:
+        app-id: ${{ vars.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+    - name: Get Preceding Release Tag
+      id: preceding-tag
+      uses: AJGranowski/preceding-tag-action@50a89255e7e2173eab3d48941b9419e5d5dc9aaa # v1.0.5
+      with:
+        regex: ${{ env.RELEASE_REGEX }}
+
+    - name: Increment And Create Release Tag
+      id: increment-tag
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        PRECEDING_RELEASE_TAG: ${{ steps.preceding-tag.outputs.tag }}
+        RELEASE_REGEX: ${{ env.RELEASE_REGEX }}
+      with:
+        github-token: ${{ steps.release-ruleset-bypass-token.outputs.token }}
+        script: |
+          core.info(`PRECEDING_RELEASE_TAG: ${process.env.PRECEDING_RELEASE_TAG}`);
+          core.info(`RELEASE_REGEX: ${process.env.RELEASE_REGEX}`);
+          const regexp = new RegExp(process.env.RELEASE_REGEX);
+          const groups = process.env.PRECEDING_RELEASE_TAG.match(regexp).groups;
+
+          // Convert string to number
+          Object.keys(groups).forEach((key) => {
+            let value = groups[key];
+            let parsedValue = parseFloat(value);
+            if (parsedValue.toString() === value) groups[key] = parsedValue;
+          });
+
+          const bumpedTag = `release-${groups.major}.${groups.minor}.${groups.patch + 1}`;
+          if (!regexp.test(bumpedTag)) {
+            throw new Error(`Bumped tag does not match RELEASE_REGEX "${bumpedTag}"`)
+          }
+
+          const bumpedRef = `refs/tags/${bumpedTag}`;
+
+          await github.rest.git.getRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: bumpedRef
+          }).then((response) => {
+            throw new Error(`Tag already exists: ${bumpedRef}`);
+          }).catch((e) => {
+            if (e != null && e.status !== 404) throw e;
+          });
+
+          await github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: bumpedRef,
+            sha: process.env.GITHUB_SHA
+          });
+
+          core.info(`Created tag: ${bumpedRef}`);
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [ci, ci-required-checks]
     permissions:
       contents: write # Needed to create a release https://docs.github.com/en/rest/releases/releases#create-a-release
 
     concurrency:
-      group: cd-${{ github.ref }}
+      group: release-${{ github.ref }}
       cancel-in-progress: true
 
     if: ${{ startsWith(github.ref, 'refs/tags/release-') }}
@@ -223,16 +248,54 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-          filter: tree:0
 
       - name: Get Latest Release Tag
-        run: echo "LATEST_RELEASE_TAG=$(git tag --list --sort=-v:refname release-* | head -1)" >> $GITHUB_ENV
+        id: latest-release-tag
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            core.setOutput("tag", await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            }).then((response) => {
+              return response.data.tag_name
+            }).catch((e) => {
+              if (e != null && e.status !== 404) return "";
+            }));
 
+      - name: Compare Against Latest Release
+        id: is-latest-release
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          LATEST_RELEASE_TAG: ${{ steps.latest-release-tag.outputs.tag }}
+        with:
+          script: |
+            const result = (() => {
+              const toVersionArray = (str) => str.split(/[^\d]+/).filter((x) => parseInt(x).toString() === x).map((x) => parseInt(x));
+              const thisReleaseTag = toVersionArray(process.env.GITHUB_REF_NAME);
+              core.info(`This Release Tag Components: ${JSON.stringify(thisReleaseTag)}`);
+              const latestReleaseTag = toVersionArray(process.env.LATEST_RELEASE_TAG);
+              core.info(`Latest Release Tag Components: ${JSON.stringify(latestReleaseTag)}`);
+
+              const minLength = Math.min(thisReleaseTag.length, latestReleaseTag.length);
+              for (let i = 0; i < minLength; i++) {
+                const difference = thisReleaseTag[i] - latestReleaseTag[i];
+                if (difference > 0) return true;
+                if (difference < 0) return false;
+              }
+              if (thisReleaseTag.length >= latestReleaseTag.length) return true;
+              return false;
+            })();
+
+            core.info(`Result: ${result}`);
+            core.setOutput("is-latest", result);
+      
       - name: Extract Version
-        run: echo "RELEASE_VERSION=$(echo "$GITHUB_REF" | cut -c 19-)" >> $GITHUB_ENV
+        id: extract-version
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            core.setOutput("version", process.env.GITHUB_REF.replace("refs/tags/release-", ""));
 
       - name: Generate Release Artifacts
         run: |
@@ -244,6 +307,8 @@ jobs:
         with:
           artifactErrorsFailBuild: true
           artifacts: "release/entrypoint,release/user-mirror,release/version"
+          draft: true
           generateReleaseNotes: true
-          makeLatest: ${{ github.ref_name == env.LATEST_RELEASE_TAG }}
-          name: Release ${{ env.RELEASE_VERSION }}
+          immutableCreate: true
+          makeLatest: ${{ steps.is-latest-release.outputs.is-latest == 'true' }}
+          name: Release ${{ steps.extract-version.outputs.version }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -141,12 +141,14 @@ jobs:
           allow: |
             network.host
           builder: ${{ steps.setup-buildx-action.outputs.name }}
-          files: compose.yml
+          files: 
+            ./compose.yml
+            src/compose.yml
           load: true
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
-          workdir: src
+          workdir: ./src
 
       - name: Run Tests
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -145,7 +145,7 @@ jobs:
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
-          source: compose.yml
+          source: .
           workdir: ./src
 
       - name: Run Tests

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -141,11 +141,11 @@ jobs:
           allow: |
             network.host
           builder: ${{ steps.setup-buildx-action.outputs.name }}
+          files: src/compose.yml
           load: true
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
-          source: src
 
       - name: Run Tests
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Validate Compose File
-        run: docker compose --file src/compose.yml config --quiet
+        run: docker compose --file compose.yml --file src/compose.yml config --quiet
 
       - name: Use Rootless Docker
         if: ${{ matrix.container-context == 'docker-rootless' }}
@@ -142,16 +142,9 @@ jobs:
             network.host
           builder: ${{ steps.setup-buildx-action.outputs.name }}
           load: true
-          files: |
-            alpine
-            busybox
-            debian
-            ubuntu
           set: |
             *.cache-from=type=local,src=/tmp/buildkit-cache
             *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
-          source: .
-          workdir: ./images
 
       - name: Run Tests
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,9 +5,8 @@ on:
   push:
     branches:
       - "**"
-      - "!dependabot/**"
     tags:
-      - "release-**"
+      - "**"
   pull_request:
     branches:
       - "**"
@@ -16,12 +15,12 @@ permissions:
   contents: read
 
 jobs:
-  changed-files:
-    name: Detect Changed Files
+  workflow-filter:
+    name: Workflow Filter
     runs-on: ubuntu-latest
     outputs:
       run-ci: ${{ github.event_name == 'workflow_dispatch' || github.ref_type == 'tag' || steps.ci-files-changed.outputs.paths_any_modified == 'true' }}
-      run-tag-for-release: ${{ github.ref == 'refs/heads/main' && env.COMMIT_IS_TAGGED != 'true' && steps.release-files-changed.outputs.paths_any_modified == 'true' }}
+      run-tag-for-release: ${{ github.ref == 'refs/heads/main' && steps.tag-check.outputs.is-commit-tagged != 'true' && steps.commit-comment.outputs.skip-auto-release != 'true' && steps.release-files-changed.outputs.paths_any_modified == 'true' }}
 
     steps:
       - name: Harden Runner
@@ -36,11 +35,12 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Check for Tag
+        id: tag-check
         run: |
           if git describe --contains "$GITHUB_SHA"; then
-            echo 'COMMIT_IS_TAGGED=true' >> "$GITHUB_ENV";
+            echo 'is-commit-tagged=true' >> "$GITHUB_OUTPUT";
           else
-            echo 'COMMIT_IS_TAGGED=false' >> "$GITHUB_ENV";
+            echo 'is-commit-tagged=false' >> "$GITHUB_OUTPUT";
           fi
 
       - name: CI Files Changed
@@ -55,15 +55,16 @@ jobs:
               - "!.github/**"
               - ".github/workflows/*.yml"
 
-      - name: Skip Auto Release
+      - name: Check for \#skip-auto-release
+        id: commit-comment
         run: |
           case "$(git show -s --format=%b "$GITHUB_REF")" in
-            *#skip-auto-release*) echo 'SKIP_AUTO_RELEASE=true' >> "$GITHUB_ENV";;
+            *#skip-auto-release*) echo 'skip-auto-release=true' >> "$GITHUB_OUTPUT";;
           esac
 
-      - name: Release Files Changed
+      - name: Release Source Files Changed
         id: release-files-changed
-        if: ${{ github.event_name != 'workflow_dispatch' && github.ref_type != 'tag' && env.SKIP_AUTO_RELEASE != 'true' }}
+        if: ${{ github.event_name != 'workflow_dispatch' && github.ref_type != 'tag' }}
         uses: step-security/changed-files@95b56dadb92a30ca9036f16423fd3c088a71ee94 # v46.0.5
         with:
           files_yaml: |
@@ -75,8 +76,8 @@ jobs:
   ci:
     name: Continuous Integration
     runs-on: ubuntu-22.04
-    needs: changed-files
-    if: ${{ needs.changed-files.outputs.run-ci == 'true' }}
+    needs: workflow-filter
+    if: ${{ needs.workflow-filter.outputs.run-ci == 'true' }}
     strategy:
       matrix:
         container-context: ["docker-default", "docker-rootless", "podman"]
@@ -137,12 +138,12 @@ jobs:
   tag-for-release:
     name: Tag for Release
     runs-on: ubuntu-latest
-    needs: [changed-files, ci]
+    needs: [workflow-filter, ci]
     environment: elevated-workflow
     concurrency:
       group: tag-for-release
 
-    if: ${{ needs.changed-files.outputs.run-tag-for-release == 'true' }}
+    if: ${{ needs.workflow-filter.outputs.run-tag-for-release == 'true' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -119,11 +119,29 @@ jobs:
           pip3 install --require-hashes --requirement /tmp/requirements.txt
           rm /tmp/requirements.txt
 
-      - name: Docker Cache
-        id: docker-cache
-        uses: ScribeMD/docker-cache@fb28c93772363301b8d0a6072ce850224b73f74e # 0.5.0
+      # https://docs.docker.com/build/ci/github-actions/cache/#github-cache
+      - name: Set up Docker CLI
+        id: setup-buildx-action
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         with:
-          key: ${{ matrix.container-context }}-${{ runner.os }}-${{ hashFiles('./images/**/Dockerfile') }}
+          name: ci
+
+      - name: Docker Cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: /tmp/buildkit-cache
+          key: buildkit-${{ runner.os }}-${{ hashFiles('./container-images/**') }}
+
+      - name: Build Docker images
+        uses: docker/bake-action@3acf805d94d93a86cce4ca44798a76464a75b88c # v6.9.0
+        with:
+          allow: |
+            network.host
+          builder: ${{ steps.setup-buildx-action.outputs.name }}
+          load: true
+          set: |
+            *.cache-from=type=local,src=/tmp/buildkit-cache
+            *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
 
       - name: Run Tests
         run: |

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,17 @@
+services:
+  alpine:
+    build:
+      context: images/alpine
+      network: host
+  busybox:
+    build:
+      context: images/busybox
+      network: host
+  debian:
+    build:
+      context: images/debian
+      network: host
+  ubuntu:
+    build:
+      context: images/ubuntu
+      network: host


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/docker-user-mirror/blob/main/CONTRIBUTING.md#contribution-guidelines
-->

## What are these changes?
* Update CI/CD to use `AJGranowski/preceding-tag-action`.
* Use an app instead of a deploy key to create protected tags.

## Why are these changes being made?
I think the workflow I made for `AJGranowski/preceding-tag-action` works well, so I'm basically copying it over here.