### PR TITLE
Match mount ownership

### DIFF
--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -235,6 +235,7 @@ else
     fi
 
     printf 'USER_MIRROR_CAPABILITIES=%s\n' "$USER_MIRROR_CAPABILITIES" >&3
+    printf 'USER_MIRROR_CHOWN_LIST=%s\n' "$USER_MIRROR_CHOWN_LIST" >&3
     printf 'USER_MIRROR_HOST_USER=%s\n' "$USER_MIRROR_HOST_USER" >&3
     printf 'USER_MIRROR_SERVICE_NAME=%s\n' "$USER_MIRROR_SERVICE_NAME" >&3
 
@@ -308,7 +309,8 @@ else
         esac
 
         if [ -n "$error" ]; then
-            printf 'error: invalid chown list object: {%s, %s, %s}\n' "$service_name" >&2; exit 1;;
+            printf 'error: invalid chown list object: [%s, %s, %s]\n' "$service_name" "$ownership" "$chown_path" >&2
+            exit 1
         fi
 
         if [ -n "$service_name" ] && [ "$service_name" != "$USER_MIRROR_SERVICE_NAME" ]; then

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -288,6 +288,7 @@ else
 
         read ownership
         read chown_path
+        unset error
 
         case "$service_name" in
             S:*) service_name="${service_name#S:}";;

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -297,7 +297,7 @@ else
 
         case "$ownership" in
             O:*) ownership="${ownership#O:}";;
-            *) error=1
+            *) error=1;;
         esac
 
         if [ -z "$ownership" ]; then
@@ -306,7 +306,7 @@ else
 
         case "$chown_path" in
             P:*) chown_path="${chown_path#P:}";;
-            *) error=1
+            *) error=1;;
         esac
 
         if [ -n "$error" ]; then

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -298,6 +298,10 @@ else
             *) error=1
         esac
 
+        if [ -z "$ownership" ]; then
+            ownership="${host_user_id}:${host_user_gid}"
+        fi
+
         case "$chown_path" in
             P:*) chown_path="${chown_path#P:}";;
             *) error=1
@@ -316,7 +320,7 @@ else
             continue
         fi
 
-        chown -c "${host_user_id}:${host_user_gid}" "$chown_path" >&3
+        chown -c "$ownership" "$chown_path" >&3
     done <<EOF
 $USER_MIRROR_CHOWN_LIST
 EOF

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -285,13 +285,27 @@ else
             continue
         fi
 
+        read ownership
+        read chown_path
+
         case "$service_name" in
-            /*)
-                chown_path="$service_name"
-                unset service_name
-                ;;
-            *) read chown_path;;
+            S:*) service_name="${service_name#S:}";;
+            *) error=1;;
         esac
+
+        case "$ownership" in
+            O:*) ownership="${ownership#O:}";;
+            *) error=1
+        esac
+
+        case "$chown_path" in
+            P:*) chown_path="${chown_path#P:}";;
+            *) error=1
+        esac
+
+        if [ -n "$error" ]; then
+            printf 'error: invalid chown list object: {%s, %s, %s}\n' "$service_name" >&2; exit 1;;
+        fi
 
         if [ -n "$service_name" ] && [ "$service_name" != "$USER_MIRROR_SERVICE_NAME" ]; then
             continue

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -237,7 +237,7 @@ EOF
 
             if [ -f "$node_source" ]; then
                 mkdir -p "$(dirname "$resolved_node_destination")" >/dev/null 2>&1 || true
-                touch "$resolved_node_destination"
+                touch "$resolved_node_destination" >/dev/null 2>&1 || true
             else
                 mkdir -p "$resolved_node_destination" >/dev/null 2>&1 || true
             fi

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -260,7 +260,7 @@ EOF
         fi
 
         read chown_path
-        ownership="$(stat -c '%g:%u' "$chown_source" 2>/dev/null || echo '')"
+        ownership="$(stat -c '%u:%g' "$chown_source" 2>/dev/null || echo '')"
         USER_MIRROR_CHOWN_LIST="$USER_MIRROR_CHOWN_LIST
 S:$service_name
 O:$ownership

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -260,7 +260,7 @@ EOF
         fi
 
         read chown_path
-        ownership="$(stat -c '%u:%g' "$chown_source" 2>/dev/null || echo '')"
+        ownership="$(stat2 '%u:%g' "$chown_source" 2>/dev/null || echo '')"
         USER_MIRROR_CHOWN_LIST="$USER_MIRROR_CHOWN_LIST
 S:$service_name
 O:$ownership
@@ -276,6 +276,15 @@ release_tag_exists() {
         2*) true;;
         *) false;;
     esac
+}
+
+# Cross-UNIX stat command
+stat2() {
+    if stat -c "$1" "$2" >/dev/null 2>&1; then
+        stat -c "$1" "$2"
+    else
+        stat -f "$1" "$2"
+    fi
 }
 
 # Check for updates, and download the latest version.

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -198,13 +198,6 @@ get_release_version() {
 # Create host items and populate chown list
 # Args: container ID (retrieved from container_create)
 prepare_environment() {
-    # Grab the USER_MIRROR_SERVICE_NAME environment variable if it exists.
-    service_name="$($CONTAINER_ENGINE inspect --format '{{range .Config.Env}}{{if and (gt (len .) 25) (eq (slice . 0 25) "USER_MIRROR_SERVICE_NAME=")}}{{slice . 25}}{{end}}{{end}}' "$1")"
-
-    # Create a list of all read/write mount destinations so they can be chown'd in the container at runtime.
-    USER_MIRROR_CHOWN_LIST="$USER_MIRROR_CHOWN_LIST
-$($CONTAINER_ENGINE inspect --format "{{range .Mounts}}{{if .RW}}{{println \"${service_name}\"}}{{println .Destination}}{{end}}{{end}}" "$1")"
-
     # Loop through bind mounts that have a non-empty mode (`create_host_path: true` sets this), and mkdir those source paths on the host.
     items="$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if and (eq .Type "bind") .Mode}}{{println .Source}}{{end}}{{end}}' "$1")"
     while read create_path; do
@@ -252,6 +245,26 @@ EOF
 $items
 EOF
 
+    done <<EOF
+$items
+EOF
+
+    # Grab the USER_MIRROR_SERVICE_NAME environment variable if it exists.
+    service_name="$($CONTAINER_ENGINE inspect --format '{{range .Config.Env}}{{if and (gt (len .) 25) (eq (slice . 0 25) "USER_MIRROR_SERVICE_NAME=")}}{{slice . 25}}{{end}}{{end}}' "$1")"
+
+    # Create a list of all read/write mount destinations so they can be chown'd in the container at runtime.
+    items="$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if .RW}}{{println .Source}}{{println .Destination}}{{end}}{{end}}' "$1")"
+    while read chown_source; do
+        if [ -z "$chown_source" ]; then
+            break
+        fi
+
+        read chown_path
+        ownership="$(stat -c '%g:%u' "$chown_source" 2>/dev/null || echo '')"
+        USER_MIRROR_CHOWN_LIST="$USER_MIRROR_CHOWN_LIST
+S:$service_name
+O:$ownership
+P:$chown_path"
     done <<EOF
 $items
 EOF


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/docker-user-mirror/blob/main/CONTRIBUTING.md#contribution-guidelines
-->

## What are these changes?
Add host ownership (GID:UID) to the chown list injected into the container, and mirror host file ownership inside the container.

## Why are these changes being made?
This change resolves #180

## Checklist before merging
- [X] `./ci` succeeds.