### PR TITLE
Small sed parsing update

### DIFF
--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -47,19 +47,6 @@ download_file() {
     fi
 }
 
-# Query GitHub for the latest release tag.
-get_latest_release_tag() {
-    response="$(curl -Ls -w '%{http_code}' 'https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/latest')"
-    case "$(echo "$response" | tail -1)" in
-        2*)
-            echo "$response" | \
-            grep -E '^\s*"tag_name":' | \
-            sed -E 's/.*"tag_name": "([^"]+)".*/\1/g'
-        ;;
-        *) false;;
-    esac
-}
-
 # Get the version ID of a release.
 # Args: release tag (defaults to latest release it not provided)
 get_release_version() {

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -116,9 +116,9 @@ update() {
 # Convert "$VERSION" to "release-**" format.
 version_to_release_tag() {
     if [ $# -eq 0 ]; then
-        echo "$VERSION" | sed -E 's/([^-]*).*/release-\1/g'
+        echo "$VERSION" | sed 's/\([^-]*\).*/release-\1/g'
     else
-        echo "$1" | sed -E 's/([^-]*).*/release-\1/g'
+        echo "$1" | sed 's/\([^-]*\).*/release-\1/g'
     fi
 }
 

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -116,9 +116,9 @@ update() {
 # Convert "$VERSION" to "release-**" format.
 version_to_release_tag() {
     if [ $# -eq 0 ]; then
-        echo "$VERSION" | sed 's/\([^-]*\).*/release-\1/g'
+        echo "release-${VERSION%-*}"
     else
-        echo "$1" | sed 's/\([^-]*\).*/release-\1/g'
+        echo "release-${1%-*}"
     fi
 }
 

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -167,19 +167,6 @@ download_file() {
     fi
 }
 
-# Query GitHub for the latest release tag.
-get_latest_release_tag() {
-    response="$(curl -Ls -w '%{http_code}' 'https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/latest')"
-    case "$(echo "$response" | tail -1)" in
-        2*)
-            echo "$response" | \
-            grep -E '^\s*"tag_name":' | \
-            sed -E 's/.*"tag_name": "([^"]+)".*/\1/g'
-        ;;
-        *) false;;
-    esac
-}
-
 # Get the version ID of a release.
 # Args: release tag (defaults to latest release it not provided)
 get_release_version() {

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -316,9 +316,9 @@ update() {
 # Convert "$VERSION" to "release-**" format.
 version_to_release_tag() {
     if [ $# -eq 0 ]; then
-        echo "$VERSION" | sed -E 's/([^-]*).*/release-\1/g'
+        echo "$VERSION" | sed 's/\([^-]*\).*/release-\1/g'
     else
-        echo "$1" | sed -E 's/([^-]*).*/release-\1/g'
+        echo "$1" | sed 's/\([^-]*\).*/release-\1/g'
     fi
 }
 

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -316,9 +316,9 @@ update() {
 # Convert "$VERSION" to "release-**" format.
 version_to_release_tag() {
     if [ $# -eq 0 ]; then
-        echo "$VERSION" | sed 's/\([^-]*\).*/release-\1/g'
+        echo "release-${VERSION%-*}"
     else
-        echo "$1" | sed 's/\([^-]*\).*/release-\1/g'
+        echo "release-${1%-*}"
     fi
 }
 


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/docker-user-mirror/blob/main/CONTRIBUTING.md#contribution-guidelines
-->

## What are these changes?
Removed all occurrences of `sed -E` from the scripts. `get_latest_release_tag` was unused, so I just removed it entirely.

## Why are these changes being made?
This change resolves #214

## Checklist before merging
- [X] `./ci` succeeds.