### PR TITLE
Small script hardening changes

### DIFF
--- a/src/compose.yml
+++ b/src/compose.yml
@@ -13,7 +13,6 @@ services:
       - CAP_DAC_OVERRIDE # Needed for Podman.
 
     cap_drop: [ALL]
-    security_opt: [no-new-privileges:true]
     entrypoint: [/entrypoint, --, sh]
     environment:
       USER_MIRROR_CAPABILITIES: # setpriv --bounding-set options. Must be a subset of cap_add. See https://www.man7.org/linux/man-pages/man1/setpriv.1.html#OPTIONS

--- a/src/compose.yml
+++ b/src/compose.yml
@@ -13,6 +13,7 @@ services:
       - CAP_DAC_OVERRIDE # Needed for Podman.
 
     cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
     entrypoint: [/entrypoint, --, sh]
     environment:
       USER_MIRROR_CAPABILITIES: # setpriv --bounding-set options. Must be a subset of cap_add. See https://www.man7.org/linux/man-pages/man1/setpriv.1.html#OPTIONS

--- a/src/image/Dockerfile.user-mirror
+++ b/src/image/Dockerfile.user-mirror
@@ -3,6 +3,6 @@
 COPY entrypoint /entrypoint
 ARG GOSU_VERSION=1.19
 ARG SETPRIV_VERSION=2.42.1
-ARG UTIL_LINUX_VERSION=2.41.3
+ARG UTIL_LINUX_VERSION=2.41
 RUN chmod +x /entrypoint && /entrypoint --setup --verbose
 ENTRYPOINT ["/entrypoint", "--"]

--- a/src/image/Dockerfile.user-mirror
+++ b/src/image/Dockerfile.user-mirror
@@ -1,8 +1,8 @@
 #{{Dockerfile}}
 
 COPY entrypoint /entrypoint
-ARG GOSU_VERSION=1.17
-ARG SETPRIV_VERSION=2.40.1
-ARG UTIL_LINUX_VERSION=2.39.3
+ARG GOSU_VERSION=1.19
+ARG SETPRIV_VERSION=2.42.1
+ARG UTIL_LINUX_VERSION=2.41.3
 RUN chmod +x /entrypoint && /entrypoint --setup --verbose
 ENTRYPOINT ["/entrypoint", "--"]

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -100,7 +100,7 @@ update() {
     fi
 
     if [ "$o_yes" != true ]; then
-        echo '\nInstall the update? (y/n)'
+        printf '\nInstall the update? (y/n)\n'
         read -r yn
         case "$yn" in
             y*) ;;

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -27,7 +27,7 @@ extract_index() {
     while [ "$count" -gt 0 ]; do
         : $((count -= 1))
         case "$str" in
-            *${delimiter}*) str="${str#*${delimiter}}";;
+            *${delimiter}*) str="${str#*"$delimiter"}";;
             *) str='';;
         esac
     done

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -104,7 +104,7 @@ update() {
         read -r yn
         case "$yn" in
             y*) ;;
-            n*) return 0;;
+            *) return 0;;
         esac
     fi
 

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -20,7 +20,7 @@ check_setpriv() {
 }
 
 # Split strings by a delimiter and extract an index. Uses space as a delimiter by default.
-extract_index() (
+extract_index() {
     str="$1"
     count="${2:-0}"
     delimiter="${3:- }"
@@ -32,7 +32,7 @@ extract_index() (
         esac
     done
     echo "${str%%${delimiter}*}"
-)
+}
 
 # Download a release file.
 # Args: release filename, output filename, release tag (defaults to latest release it not provided)

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -21,17 +21,19 @@ check_setpriv() {
 
 # Split strings by a delimiter and extract an index. Uses space as a delimiter by default.
 extract_index() {
-    str="$1"
-    count="${2:-0}"
-    delimiter="${3:- }"
-    while [ "$count" -gt 0 ]; do
-        : $((count -= 1))
-        case "$str" in
-            *${delimiter}*) str="${str#*"$delimiter"}";;
-            *) str='';;
-        esac
-    done
-    echo "${str%%${delimiter}*}"
+    (
+        str="$1"
+        count="${2:-0}"
+        delimiter="${3:- }"
+        while [ "$count" -gt 0 ]; do
+            : $((count -= 1))
+            case "$str" in
+                *"$delimiter"*) str="${str#*"$delimiter"}" ;;
+                *) str='' ;;
+            esac
+        done
+        printf '%s\n' "${str%%"$delimiter"*}"
+    )
 }
 
 # Download a release file.

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -56,8 +56,8 @@ get_release_version() {
         response="$(curl -Ls -w '\n%{http_code}' "https://github.com/AJGranowski/docker-user-mirror/releases/download/${1}/version")"
     fi
 
-    case "$(echo "$response" | tail -1)" in
-        2*) echo "$response" | head -1;;
+    case "$(echo "$response" | tail -n 1)" in
+        2*) echo "$response" | head -n 1;;
         *) false;;
     esac
 }

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -275,12 +275,12 @@ else
 
         IFS= read -r ownership || {
             printf 'Malformed ownership\n' >&2
-            return 1
+            exit 1
         }
 
         IFS= read -r chown_path || {
             printf 'Malformed chown_path\n' >&2
-            return 1
+            exit 1
         }
 
         unset error

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -57,7 +57,7 @@ container_create() {
                 break
             fi
 
-            items="$(docker compose config --services)"
+            items="$($COMPOSE_ENGINE config --services)"
             while IFS= read -r service; do
                 if [ "$arg" = "$service" ]; then
                     unset create_all_containers

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -310,7 +310,7 @@ update() {
     fi
 
     if [ "$o_yes" != true ]; then
-        echo '\nInstall the update? (y/n)'
+        printf '\nInstall the update? (y/n)\n'
         read -r yn
         case "$yn" in
             y*) ;;

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -220,13 +220,13 @@ EOF
                 return 1
             }
 
-            # Find replace
-            resolved_node_destination="$(echo "$node_destination" | sed -e "s|^${edge_destination}/|${edge_source}/|g")"
+            printf 'example:\n%s\n%s\n%s\n%s\n' "$edge_source" "$edge_destination" "$node_source" "$node_destination"
 
-            if [ "$resolved_node_destination" = "$node_destination" ]; then
-                # Skip this pair if no resolution was made.
-                continue
-            fi
+            # Find replace
+            case "$node_destination" in
+                "${edge_destination}/"*) resolved_node_destination="${edge_source}/${node_destination#"${edge_destination}/"}";;
+                *) continue;; # Skip this pair if no resolution was made.
+            esac
 
             if [ -f "$node_source" ]; then
                 mkdir -p "$(dirname "$resolved_node_destination")" >/dev/null 2>&1 || true

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -314,7 +314,7 @@ update() {
         read -r yn
         case "$yn" in
             y*) ;;
-            n*) return 0;;
+            *) return 0;;
         esac
     fi
 

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -220,8 +220,6 @@ EOF
                 return 1
             }
 
-            printf 'example:\n%s\n%s\n%s\n%s\n' "$edge_source" "$edge_destination" "$node_source" "$node_destination"
-
             # Find replace
             case "$node_destination" in
                 "${edge_destination}/"*) resolved_node_destination="${edge_source}/${node_destination#"${edge_destination}/"}";;

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -57,7 +57,7 @@ container_create() {
                 break
             fi
 
-            items="$($COMPOSE_ENGINE config --services)"
+            items="$($COMPOSE_ENGINE $compose_configuration_files config --services)"
             while IFS= read -r service; do
                 if [ "$arg" = "$service" ]; then
                     unset create_all_containers

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -176,8 +176,8 @@ get_release_version() {
         response="$(curl -Ls -w '\n%{http_code}' "https://github.com/AJGranowski/docker-user-mirror/releases/download/${1}/version")"
     fi
 
-    case "$(echo "$response" | tail -1)" in
-        2*) echo "$response" | head -1;;
+    case "$(echo "$response" | tail -n 1)" in
+        2*) echo "$response" | head -n 1;;
         *) false;;
     esac
 }
@@ -230,6 +230,8 @@ EOF
                 mkdir -p "$(dirname "$resolved_node_destination")" >/dev/null 2>&1 || true
                 touch "$resolved_node_destination" >/dev/null 2>&1 || true
             else
+                # The vast majority of mounts are directories, not files.
+                # Assume paths that don't exist on the host are intended as directories.
                 mkdir -p "$resolved_node_destination" >/dev/null 2>&1 || true
             fi
         done <<EOF

--- a/test/regex-path-test
+++ b/test/regex-path-test
@@ -1,0 +1,39 @@
+#!/bin/sh
+THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)"
+. "$THIS_SCRIPT_DIR/../scripts/test-utilities"
+
+# Skip on Podman
+if [ "$CONTAINER_ENGINE" = 'podman' ]; then
+    exit 0
+fi
+
+mv compose.yml compose1.yml
+cat <<EOF > compose2.yml
+services:
+  sh:
+    volumes:
+      - type: bind
+        source: ./dot-directory
+        target: /docker.user.mirror
+        bind:
+          create_host_path: true
+      - type: volume
+        source: volume
+        target: /docker-user-mirror/volume
+volumes:
+  volume:
+EOF
+
+$COMPOSE_ENGINE -f compose1.yml -f compose2.yml config > compose.yml
+rm compose1.yml
+rm compose2.yml
+
+$COMPOSE_ENGINE build
+./user-mirror $COMPOSE_ENGINE run --rm sh -c 'true' 2>/dev/null
+
+# /docker-user-mirror/volume should only match ./:/docker-user-mirror NOT ./dot-directory:/docker.user.mirror
+# Fail if it does, and it creates a new directory in ./dot-directory:/docker.user.mirror
+if [ -d './dot-directory/volume' ]; then
+    printf 'Created directory on the wrong path (/docker.user.mirror instead of /docker-user-mirror)\n' >&2
+    exit 1
+fi


### PR DESCRIPTION
## What are these changes?
Fixes a few bugs here and there and further hardens the scripts.

## Why are these changes being made?
* `tail/head -n 1` is the POSIX standard.
* `echo` might not work with `\n`
* Parameter expansion is more resilient than `sed` to evaluate `resolved_node_destination`
* Fix invalid top-level return statements.

## Checklist before merging
- [x] `./ci` succeeds.