### PR TITLE
Add `--print-env` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ You can rename this script to whatever best fits your project.
 * `--docker-compose`: Use `docker` and `docker-compose` rather than inferring from the arguments.
 * `--podman`: Use `podman` and `podman compose` rather than inferring from the arguments.
 * `--podman-compose`: Use `podman` and `podman-compose` rather than inferring from the arguments.
+* `--print-env`: Stop just before execution and print environment variables to standard output in `.env` format. (`./user-mirror --print-env docker compose up > .env`)
 * `--update`: Check for updates. Pass `-y` or `--yes` to install updates without prompting.
 * `--version`: Print the version of this script.
 * `--`: Stop parsing `user-mirror` options.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can rename this script to whatever best fits your project.
 * `--docker-compose`: Use `docker` and `docker-compose` rather than inferring from the arguments.
 * `--podman`: Use `podman` and `podman compose` rather than inferring from the arguments.
 * `--podman-compose`: Use `podman` and `podman-compose` rather than inferring from the arguments.
-* `--print-env`: Stop just before execution and print environment variables to standard output in `.env` format. (`./user-mirror --print-env docker compose up > .env`)
+* `--print-env`: Stop just before launching the container, and print environment variables to standard output in `.env` format instead. (`./user-mirror --print-env docker compose up > .env`)
 * `--update`: Check for updates. Pass `-y` or `--yes` to install updates without prompting.
 * `--version`: Print the version of this script.
 * `--`: Stop parsing `user-mirror` options.

--- a/src/image/entrypoint
+++ b/src/image/entrypoint
@@ -298,6 +298,8 @@ else
         esac
 
         if [ -z "$ownership" ]; then
+            continue
+        elif [ "$ownership" = 'CONTAINER_USER' ]; then
             ownership="${host_user_id}:${host_user_gid}"
         fi
 

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -506,7 +506,11 @@ if [ -n "$USER_MIRROR_CHOWN_LIST" ]; then
 fi
 
 if [ "$o_print_env" = true ]; then
-    printf "USER_MIRROR_HOST_USER='%s'\nUSER_MIRROR_CHOWN_LIST='%s'\n" "$USER_MIRROR_HOST_USER" "$USER_MIRROR_CHOWN_LIST"
+    printf "USER_MIRROR_HOST_USER='%s'\n" "$USER_MIRROR_HOST_USER"
+    if [ -n "$USER_MIRROR_CHOWN_LIST" ]; then
+        printf "USER_MIRROR_CHOWN_LIST='%s'\n" "$USER_MIRROR_CHOWN_LIST"
+    fi
+
     exit 0
 fi
 

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -262,11 +262,12 @@ EOF
             return 1
         }
 
-        if [ "$mount_type" = 'volume' ]; then
-            ownership='CONTAINER_USER'
-        else
+        if [ "$mount_type" = 'bind' ]; then
             ownership="$(stat2 '%u:%g' "$chown_source" 2>/dev/null || echo '')"
+        else
+            ownership='CONTAINER_USER'
         fi
+
         USER_MIRROR_CHOWN_LIST="${USER_MIRROR_CHOWN_LIST}${USER_MIRROR_CHOWN_LIST:+
 }S:${service_name}
 O:${ownership}

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -351,6 +351,9 @@ while [ $# -gt 0 ]; do
             COMPOSE_ENGINE='podman-compose'
             CONTAINER_ENGINE='podman'
             ;;
+        --print-env)
+            o_print_env=true
+            ;;
         --update)
             o_update=true
             ;;
@@ -491,6 +494,11 @@ done
 export USER_MIRROR_HOST_USER
 if [ -n "$USER_MIRROR_CHOWN_LIST" ]; then
     export USER_MIRROR_CHOWN_LIST
+fi
+
+if [ "$o_print_env" = true ]; then
+    printf 'USER_MIRROR_HOST_USER="%s"\nUSER_MIRROR_CHOWN_LIST="%s"\n' "$USER_MIRROR_HOST_USER" "$USER_MIRROR_CHOWN_LIST"
+    exit 0
 fi
 
 exec "$@"

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -246,18 +246,27 @@ EOF
     service_name="$($CONTAINER_ENGINE inspect --format '{{range .Config.Env}}{{if and (gt (len .) 25) (eq (slice . 0 25) "USER_MIRROR_SERVICE_NAME=")}}{{slice . 25}}{{end}}{{end}}' "$1")"
 
     # Create a list of all read/write mount destinations so they can be chown'd in the container at runtime.
-    items="$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if .RW}}{{println .Source}}{{println .Destination}}{{end}}{{end}}' "$1")"
-    while IFS= read -r chown_source; do
-        if [ -z "$chown_source" ]; then
+    items="$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if .RW}}{{println .Type}}{{println .Source}}{{println .Destination}}{{end}}{{end}}' "$1")"
+    while IFS= read -r mount_type; do
+        if [ -z "$mount_type" ]; then
             break
         fi
+
+        IFS= read -r chown_source || {
+            printf 'Malformed chown_source\n' >&2
+            return 1
+        }
 
         IFS= read -r chown_path || {
             printf 'Malformed chown_path\n' >&2
             return 1
         }
 
-        ownership="$(stat2 '%u:%g' "$chown_source" 2>/dev/null || echo '')"
+        if [ "$mount_type" = 'volume' ]; then
+            ownership='CONTAINER_USER'
+        else
+            ownership="$(stat2 '%u:%g' "$chown_source" 2>/dev/null || echo '')"
+        fi
         USER_MIRROR_CHOWN_LIST="${USER_MIRROR_CHOWN_LIST}${USER_MIRROR_CHOWN_LIST:+
 }S:${service_name}
 O:${ownership}
@@ -497,7 +506,7 @@ if [ -n "$USER_MIRROR_CHOWN_LIST" ]; then
 fi
 
 if [ "$o_print_env" = true ]; then
-    printf 'USER_MIRROR_HOST_USER="%s"\nUSER_MIRROR_CHOWN_LIST="%s"\n' "$USER_MIRROR_HOST_USER" "$USER_MIRROR_CHOWN_LIST"
+    printf "USER_MIRROR_HOST_USER='%s'\nUSER_MIRROR_CHOWN_LIST='%s'\n" "$USER_MIRROR_HOST_USER" "$USER_MIRROR_CHOWN_LIST"
     exit 0
 fi
 

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -258,10 +258,10 @@ EOF
         }
 
         ownership="$(stat2 '%u:%g' "$chown_source" 2>/dev/null || echo '')"
-        USER_MIRROR_CHOWN_LIST="$USER_MIRROR_CHOWN_LIST
-S:$service_name
-O:$ownership
-P:$chown_path"
+        USER_MIRROR_CHOWN_LIST="${USER_MIRROR_CHOWN_LIST}${USER_MIRROR_CHOWN_LIST:+
+}S:${service_name}
+O:${ownership}
+P:${chown_path}"
     done <<EOF
 $items
 EOF

--- a/src/user-mirror
+++ b/src/user-mirror
@@ -263,7 +263,7 @@ EOF
         }
 
         if [ "$mount_type" = 'bind' ]; then
-            ownership="$(stat2 '%u:%g' "$chown_source" 2>/dev/null || echo '')"
+            ownership="$(stat2 '%u:%g' "$chown_source")"
         else
             ownership='CONTAINER_USER'
         fi

--- a/test/print-env-test
+++ b/test/print-env-test
@@ -3,20 +3,12 @@ THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)"
 . "$THIS_SCRIPT_DIR/../scripts/test-utilities"
 
 unset USER_MIRROR_HOST_USER
-unset USER_MIRROR_CHOWN_LIST
 
 $COMPOSE_ENGINE build
-./user-mirror --print-env $COMPOSE_ENGINE run --rm sh -c 'true' > output.env
-
-cat output.env
+./user-mirror $COMPOSE_ENGINE run --rm sh -c 'printf "Should not have launched container" >&2; false' > output.env
 
 if [ -n "$USER_MIRROR_HOST_USER" ]; then
     printf 'Expected USER_MIRROR_HOST_USER to be empty, got this instead: %s\n' "$USER_MIRROR_HOST_USER" >&2
-    exit 1
-fi
-
-if [ -n "$USER_MIRROR_CHOWN_LIST" ]; then
-    printf 'Expected USER_MIRROR_CHOWN_LIST to be empty, got this instead: %s\n' "$USER_MIRROR_CHOWN_LIST" >&2
     exit 1
 fi
 
@@ -24,10 +16,5 @@ fi
 
 if [ -z "$USER_MIRROR_HOST_USER" ]; then
     printf 'Expected USER_MIRROR_HOST_USER to be non-empty after sourcing output.env\n' >&2
-    exit 1
-fi
-
-if [ -z "$USER_MIRROR_CHOWN_LIST" ]; then
-    printf 'Expected USER_MIRROR_CHOWN_LIST to be non-empty after sourcing output.env\n' >&2
     exit 1
 fi

--- a/test/print-env-test
+++ b/test/print-env-test
@@ -5,7 +5,7 @@ THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)"
 unset USER_MIRROR_HOST_USER
 
 $COMPOSE_ENGINE build
-./user-mirror $COMPOSE_ENGINE run --rm sh -c 'printf "Should not have launched container" >&2; false' > output.env
+./user-mirror --print-env $COMPOSE_ENGINE run --rm sh -c 'printf "Should not have launched container" >&2; false' > output.env
 
 if [ -n "$USER_MIRROR_HOST_USER" ]; then
     printf 'Expected USER_MIRROR_HOST_USER to be empty, got this instead: %s\n' "$USER_MIRROR_HOST_USER" >&2

--- a/test/print-env-test
+++ b/test/print-env-test
@@ -1,0 +1,31 @@
+#!/bin/sh
+THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)"
+. "$THIS_SCRIPT_DIR/../scripts/test-utilities"
+
+unset USER_MIRROR_HOST_USER
+unset USER_MIRROR_CHOWN_LIST
+
+$COMPOSE_ENGINE build
+./user-mirror --print-env $COMPOSE_ENGINE run --rm sh -c 'true' > output.env
+
+if [ -n "$USER_MIRROR_HOST_USER" ]; then
+    printf 'Expected USER_MIRROR_HOST_USER to be empty, got this instead: %s\n' "$USER_MIRROR_HOST_USER" >&2
+    exit 1
+fi
+
+if [ -n "$USER_MIRROR_CHOWN_LIST" ]; then
+    printf 'Expected USER_MIRROR_CHOWN_LIST to be empty, got this instead: %s\n' "$USER_MIRROR_CHOWN_LIST" >&2
+    exit 1
+fi
+
+. ./output.env
+
+if [ -z "$USER_MIRROR_HOST_USER" ]; then
+    printf 'Expected USER_MIRROR_HOST_USER to be non-empty after sourcing output.env\n' >&2
+    exit 1
+fi
+
+if [ -z "$USER_MIRROR_CHOWN_LIST" ]; then
+    printf 'Expected USER_MIRROR_CHOWN_LIST to be non-empty after sourcing output.env\n' >&2
+    exit 1
+fi

--- a/test/print-env-test
+++ b/test/print-env-test
@@ -8,6 +8,8 @@ unset USER_MIRROR_CHOWN_LIST
 $COMPOSE_ENGINE build
 ./user-mirror --print-env $COMPOSE_ENGINE run --rm sh -c 'true' > output.env
 
+cat output.env
+
 if [ -n "$USER_MIRROR_HOST_USER" ]; then
     printf 'Expected USER_MIRROR_HOST_USER to be empty, got this instead: %s\n' "$USER_MIRROR_HOST_USER" >&2
     exit 1

--- a/test/regex-path-test
+++ b/test/regex-path-test
@@ -2,11 +2,6 @@
 THIS_SCRIPT_DIR="$(dirname "$0" | xargs realpath)"
 . "$THIS_SCRIPT_DIR/../scripts/test-utilities"
 
-# Skip on Podman
-if [ "$CONTAINER_ENGINE" = 'podman' ]; then
-    exit 0
-fi
-
 mv compose.yml compose1.yml
 cat <<EOF > compose2.yml
 services:


### PR DESCRIPTION
## What are these changes?
Add a flag to print environment variables to stdout and skip execution.

## Why are these changes being made?
This PR resolves #224 

## Notes
Here's an example output:
```env
USER_MIRROR_HOST_USER='host:1000:host:1000'
USER_MIRROR_CHOWN_LIST='S:npm
O:CONTAINER_USER
P:/app/node_modules
S:npm
O:1000:1000
P:/app
S:npm
O:1000:1000
P:/tmp/npm-cache
S:npm
O:1000:1000
P:/tmp/.cache/preceding-tag-action'
```

## Checklist before merging
- [ ] `./ci` succeeds.